### PR TITLE
Avoid having an explicit node typings requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,6 @@
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "dependencies": {
-    "@types/minimist": "^1.1.29",
-    "@types/node": "^6.0.42",
     "minimist": "^1.2.0",
     "path-posix": "^1.0.0",
     "phosphor": "^0.5.0",
@@ -15,6 +13,7 @@
   },
   "devDependencies": {
     "@types/expect.js": "^0.3.29",
+    "@types/minimist": "^1.1.29",
     "@types/mocha": "^2.2.32",
     "@types/text-encoding": "0.0.30",
     "@types/ws": "0.0.33",

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -1,6 +1,7 @@
 
 /// <reference path="../typings/path-posix/path-posix.d.ts"/>
 /// <reference path="../typings/url-join/url-join.d.ts"/>
+/// <reference path="../typings/url/url.d.ts"/>
 
 /*
  * TODO: remove the below typings after typedoc understands the lib compiler option

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -8,7 +8,6 @@
  * When this happens, use the typescript compiler option:
  * "lib": ["dom", "es5", "es2015.promise", "es2015.collection"],
  */
-/// <reference path="../node_modules/@types/node/index.d.ts"/>
 /// <reference path="../node_modules/@types/minimist/index.d.ts"/>
 /// <reference path="../node_modules/@types/text-encoding/index.d.ts"/>
 /// <reference path="../node_modules/typescript/lib/lib.es2015.promise.d.ts"/>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -63,6 +63,27 @@ function uuid(): string {
 }
 
 
+
+/**
+ * The interface for a url.
+ */
+export
+interface IUrl {
+  href?: string;
+  protocol?: string;
+  auth?: string;
+  hostname?: string;
+  port?: string;
+  host?: string;
+  pathname?: string;
+  search?: string;
+  query?: string | any;
+  slashes?: boolean;
+  hash?: string;
+  path?: string;
+}
+
+
 /**
  * Parse a url into a URL object.
  *
@@ -82,7 +103,7 @@ function uuid(): string {
  * @returns A URL object.
  */
 export
-function urlParse(urlStr: string, parseQueryString?: boolean, slashesDenoteHost?: boolean): url.Url {
+function urlParse(urlStr: string, parseQueryString?: boolean, slashesDenoteHost?: boolean): IUrl {
   return url.parse(urlStr, parseQueryString, slashesDenoteHost);
 }
 

--- a/test/src/typings.d.ts
+++ b/test/src/typings.d.ts
@@ -9,7 +9,6 @@
  */
 /// <reference path="../../node_modules/@types/expect.js/index.d.ts"/>
 /// <reference path="../../node_modules/@types/mocha/index.d.ts"/>
-/// <reference path="../../node_modules/@types/node/index.d.ts"/>
 /// <reference path="../../node_modules/@types/text-encoding/index.d.ts"/>
 /// <reference path="../../node_modules/@types/ws/index.d.ts"/>
 /// <reference path="../../node_modules/typescript/lib/lib.es2015.promise.d.ts"/>

--- a/typings/url/url.d.ts
+++ b/typings/url/url.d.ts
@@ -1,0 +1,27 @@
+// Type definitions for url from
+// Type definitions for Node.js v6.x
+// Project: http://nodejs.org/
+// Definitions by: Microsoft TypeScript <http://typescriptlang.org>, DefinitelyTyped <https://github.com/DefinitelyTyped/DefinitelyTyped>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module "url" {
+    export interface Url {
+        href?: string;
+        protocol?: string;
+        auth?: string;
+        hostname?: string;
+        port?: string;
+        host?: string;
+        pathname?: string;
+        search?: string;
+        query?: string | any;
+        slashes?: boolean;
+        hash?: string;
+        path?: string;
+    }
+
+    export function parse(urlStr: string, parseQueryString?: boolean, slashesDenoteHost?: boolean): Url;
+    export function format(url: Url): string;
+    export function resolve(from: string, to: string): string;
+}
+


### PR DESCRIPTION
We also don't need the `minimist` `@typings` in `dependencies`, because it isn't in the compiled `.d.ts` file.

cc @jasongrout 