### PR TITLE
More API Cleanup

### DIFF
--- a/src/contents/index.ts
+++ b/src/contents/index.ts
@@ -5,10 +5,6 @@ import * as posix
  from 'path-posix';
 
 import {
-  IIterator, iter
-} from 'phosphor/lib/algorithm/iteration';
-
-import {
   JSONObject
 } from 'phosphor/lib/algorithm/json';
 
@@ -274,7 +270,7 @@ namespace Contents {
      * @returns A promise which resolves with a list of checkpoint models for
      *    the file.
      */
-    listCheckpoints(path: string): Promise<IIterator<ICheckpointModel>>;
+    listCheckpoints(path: string): Promise<ICheckpointModel[]>;
 
     /**
      * Restore a file to a known checkpoint state.
@@ -614,7 +610,7 @@ class ContentsManager implements Contents.IManager {
    * #### Notes
    * Uses the [Jupyter Notebook API](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/notebook/master/notebook/services/api/api.yaml#!/contents) and validates the response model.
    */
-  listCheckpoints(path: string): Promise<IIterator<Contents.ICheckpointModel>> {
+  listCheckpoints(path: string): Promise<Contents.ICheckpointModel[]> {
     let ajaxSettings = this.ajaxSettings;
     ajaxSettings.method = 'GET';
     ajaxSettings.dataType = 'json';
@@ -635,7 +631,7 @@ class ContentsManager implements Contents.IManager {
           return utils.makeAjaxError(success, err.message);
         }
       }
-      return iter(success.data);
+      return success.data;
     });
   }
 

--- a/src/kernel/comm.ts
+++ b/src/kernel/comm.ts
@@ -10,7 +10,7 @@ import {
 } from 'phosphor/lib/core/disposable';
 
 import {
-  IKernel, Kernel
+  Kernel
 } from './kernel';
 
 import {
@@ -26,7 +26,7 @@ class CommHandler extends DisposableDelegate implements Kernel.IComm {
   /**
    * Construct a new comm channel.
    */
-  constructor(target: string, id: string, kernel: IKernel, disposeCb: () => void) {
+  constructor(target: string, id: string, kernel: Kernel.IKernel, disposeCb: () => void) {
     super(disposeCb);
     this._id = id;
     this._target = target;
@@ -199,7 +199,7 @@ class CommHandler extends DisposableDelegate implements Kernel.IComm {
 
   private _target = '';
   private _id = '';
-  private _kernel: IKernel = null;
+  private _kernel: Kernel.IKernel = null;
   private _onClose: (msg: KernelMessage.ICommCloseMsg) => void = null;
   private _onMsg: (msg: KernelMessage.ICommMsgMsg) => void = null;
 }

--- a/src/kernel/default.ts
+++ b/src/kernel/default.ts
@@ -14,10 +14,6 @@ import {
 } from 'phosphor/lib/algorithm/searching';
 
 import {
-  ISequence
-} from 'phosphor/lib/algorithm/sequence';
-
-import {
   Vector
 } from 'phosphor/lib/collections/vector';
 
@@ -967,7 +963,7 @@ namespace DefaultKernel {
    * The promise is fulfilled on a valid response and rejected otherwise.
    */
   export
-  function listRunning(options: Kernel.IOptions = {}): Promise<ISequence<Kernel.IModel>> {
+  function listRunning(options: Kernel.IOptions = {}): Promise<Kernel.IModel[]> {
     return Private.listRunning(options);
   }
 
@@ -1082,7 +1078,7 @@ namespace Private {
    * The promise is fulfilled on a valid response and rejected otherwise.
    */
   export
-  function listRunning(options: Kernel.IOptions = {}): Promise<ISequence<Kernel.IModel>> {
+  function listRunning(options: Kernel.IOptions = {}): Promise<Kernel.IModel[]> {
     let baseUrl = options.baseUrl || utils.getBaseUrl();
     let url = utils.urlPathJoin(baseUrl, KERNEL_SERVICE_URL);
     let ajaxSettings: IAjaxSettings = utils.copy(options.ajaxSettings || {});
@@ -1104,7 +1100,7 @@ namespace Private {
           return utils.makeAjaxError(success, err.message);
         }
       }
-      return new Vector(success.data);
+      return success.data;
     }, onKernelError);
   }
 

--- a/src/kernel/kernel.ts
+++ b/src/kernel/kernel.ts
@@ -118,13 +118,13 @@ namespace Kernel {
      * is not given or is `false`, the future is disposed when an idle status
      * message is received.
      *
-     * If `disposeOnDone` is given and `false`, the Future will not be disposed
+     * If `disposeOnDone` is given and `false`, the future will not be disposed
      * of when the future is done, instead relying on the caller to dispose of it.
      * This allows for the handling of out-of-order output from ill-behaved kernels.
      *
      * All replies are validated as valid kernel messages.
      *
-     * If the kernel status is `Dead`, this will throw an error.
+     * If the kernel status is `'dead'`, this will throw an error.
      */
     sendShellMessage(msg: KernelMessage.IShellMessage, expectReply?: boolean, disposeOnDone?: boolean): Kernel.IFuture;
 
@@ -138,7 +138,7 @@ namespace Kernel {
      *
      * It is assumed that the API call does not mutate the kernel id or name.
      *
-     * The promise will be rejected if the kernel status is `Dead` or if the
+     * The promise will be rejected if the kernel status is `'dead'` or if the
      * request fails or the response is invalid.
      */
     interrupt(): Promise<void>;
@@ -155,7 +155,7 @@ namespace Kernel {
      *
      * It is assumed that the API call does not mutate the kernel id or name.
      *
-     * The promise will be rejected if the kernel status is `Dead` or if the
+     * The promise will be rejected if the kernel status is `'dead'` or if the
      * request fails or the response is invalid.
      */
     restart(): Promise<void>;
@@ -178,7 +178,7 @@ namespace Kernel {
      * On a valid response, closes the websocket and disposes of the kernel
      * object, and fulfills the promise.
      *
-     * The promise will be rejected if the kernel status is `Dead` or if the
+     * The promise will be rejected if the kernel status is `'dead'` or if the
      * request fails or the response is invalid.
      */
     shutdown(): Promise<void>;

--- a/src/kernel/kernel.ts
+++ b/src/kernel/kernel.ts
@@ -6,10 +6,6 @@ import {
 } from 'phosphor/lib/algorithm/json';
 
 import {
-  ISequence
-} from 'phosphor/lib/algorithm/sequence';
-
-import {
   IDisposable
 } from 'phosphor/lib/core/disposable';
 
@@ -367,7 +363,7 @@ namespace Kernel {
    * The promise is fulfilled on a valid response and rejected otherwise.
    */
   export
-  function listRunning(options: Kernel.IOptions = {}): Promise<ISequence<Kernel.IModel>> {
+  function listRunning(options: Kernel.IOptions = {}): Promise<Kernel.IModel[]> {
     return DefaultKernel.listRunning(options);
   }
 
@@ -467,7 +463,7 @@ namespace Kernel {
     /**
      * A signal emitted when the running kernels change.
      */
-    runningChanged: ISignal<IManager, ISequence<IModel>>;
+    runningChanged: ISignal<IManager, IModel[]>;
 
     /**
      * Get the available kernel specs.
@@ -485,7 +481,7 @@ namespace Kernel {
      * This will emit a [[runningChanged]] signal if the value
      * has changed since the last fetch.
      */
-    listRunning(options?: IOptions): Promise<ISequence<IModel>>;
+    listRunning(options?: IOptions): Promise<IModel[]>;
 
     /**
      * Start a new kernel.

--- a/src/kernel/manager.ts
+++ b/src/kernel/manager.ts
@@ -2,20 +2,8 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  iter, toArray
-} from 'phosphor/lib/algorithm/iteration';
-
-import {
   deepEqual
 } from 'phosphor/lib/algorithm/json';
-
-import {
-  ISequence
-} from 'phosphor/lib/algorithm/sequence';
-
-import {
-  Vector
-} from 'phosphor/lib/collections/vector';
 
 import {
   ISignal, clearSignalData, defineSignal
@@ -51,7 +39,7 @@ class KernelManager implements Kernel.IManager {
   /**
    * A signal emitted when the running kernels change.
    */
-  runningChanged: ISignal<this, ISequence<Kernel.IModel>>;
+  runningChanged: ISignal<this, Kernel.IModel[]>;
 
   /**
    * Test whether the terminal manager is disposed.
@@ -93,11 +81,10 @@ class KernelManager implements Kernel.IManager {
    *
    * @param options - Overrides for the default options.
    */
-  listRunning(options?: Kernel.IOptions): Promise<ISequence<Kernel.IModel>> {
+  listRunning(options?: Kernel.IOptions): Promise<Kernel.IModel[]> {
     return Kernel.listRunning(this._getOptions(options)).then(running => {
-      let value = toArray(running);
-      if (!deepEqual(value, this._running)) {
-        this._running = value;
+      if (!deepEqual(running, this._running)) {
+        this._running = running.slice();
         this.runningChanged.emit(running);
       }
       return running;

--- a/src/kernel/manager.ts
+++ b/src/kernel/manager.ts
@@ -25,7 +25,7 @@ import * as utils
   from '../utils';
 
 import {
-  IKernel, Kernel
+  Kernel
 } from './kernel';
 
 
@@ -94,13 +94,13 @@ class KernelManager implements Kernel.IManager {
    * @param options - Overrides for the default options.
    */
   listRunning(options?: Kernel.IOptions): Promise<ISequence<Kernel.IModel>> {
-    return Kernel.listRunning(this._getOptions(options)).then(it => {
-      let running = toArray(it);
-      if (!deepEqual(running, this._running)) {
-        this._running = running;
-        this.runningChanged.emit(new Vector(this._running));
+    return Kernel.listRunning(this._getOptions(options)).then(running => {
+      let value = toArray(running);
+      if (!deepEqual(value, this._running)) {
+        this._running = value;
+        this.runningChanged.emit(running);
       }
-      return iter(running);
+      return running;
     });
   }
 
@@ -113,7 +113,7 @@ class KernelManager implements Kernel.IManager {
    * This will emit [[runningChanged]] if the running kernels list
    * changes.
    */
-  startNew(options?: Kernel.IOptions): Promise<IKernel> {
+  startNew(options?: Kernel.IOptions): Promise<Kernel.IKernel> {
     return Kernel.startNew(this._getOptions(options));
   }
 
@@ -131,7 +131,7 @@ class KernelManager implements Kernel.IManager {
    *
    * @param options - Overrides for the default options.
    */
-  connectTo(id: string, options?: Kernel.IOptions): Promise<IKernel> {
+  connectTo(id: string, options?: Kernel.IOptions): Promise<Kernel.IKernel> {
     return Kernel.connectTo(id, this._getOptions(options));
   }
 

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -33,48 +33,48 @@ import {
   IAjaxSettings, getBaseUrl
 } from './utils';
 
-/**
- * A service manager interface.
- */
-export
-interface IServiceManager extends IDisposable {
-  /**
-   * A signal emitted when the specs change on the service manager.
-   */
-  specsChanged: ISignal<IServiceManager, Kernel.ISpecModels>;
-
-  /**
-   * The kernel specs for the manager.
-   */
-  readonly kernelspecs: Kernel.ISpecModels;
-
-  /**
-   * The kernel manager for the manager.
-   */
-  readonly kernels: Kernel.IManager;
-
-  /**
-   * The session manager for the manager.
-   */
-  readonly sessions: Session.IManager;
-
-  /**
-   * The contents manager for the manager.
-   */
-  readonly contents: Contents.IManager;
-
-  /**
-   * The terminals manager for the manager.
-   */
-  readonly terminals: TerminalSession.IManager;
-}
-
 
 /**
  * The namespace for `ServiceManager` statics.
  */
 export
 namespace ServiceManager {
+  /**
+   * A service manager interface.
+   */
+  export
+  interface IManager extends IDisposable {
+    /**
+     * A signal emitted when the specs change on the service manager.
+     */
+    specsChanged: ISignal<IManager, Kernel.ISpecModels>;
+
+    /**
+     * The kernel specs for the manager.
+     */
+    readonly kernelspecs: Kernel.ISpecModels;
+
+    /**
+     * The kernel manager for the manager.
+     */
+    readonly kernels: Kernel.IManager;
+
+    /**
+     * The session manager for the manager.
+     */
+    readonly sessions: Session.IManager;
+
+    /**
+     * The contents manager for the manager.
+     */
+    readonly contents: Contents.IManager;
+
+    /**
+     * The terminals manager for the manager.
+     */
+    readonly terminals: TerminalSession.IManager;
+  }
+
   /**
    * Create a new service manager.
    *
@@ -83,7 +83,7 @@ namespace ServiceManager {
    * @returns A promise that resolves with a service manager.
    */
   export
-  function create(options: IOptions = {}): Promise<IServiceManager> {
+  function create(options: IOptions = {}): Promise<IManager> {
     options.baseUrl = options.baseUrl || getBaseUrl();
     options.ajaxSettings = options.ajaxSettings || {};
     if (options.kernelspecs) {
@@ -125,7 +125,7 @@ namespace ServiceManager {
 /**
  * An implementation of a services manager.
  */
-class DefaultServiceManager implements IServiceManager {
+class DefaultServiceManager implements ServiceManager.IManager {
   /**
    * Construct a new services provider.
    */

--- a/src/session/default.ts
+++ b/src/session/default.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  IIterator, iter
+  each, toArray
 } from 'phosphor/lib/algorithm/iteration';
 
 import {
@@ -10,11 +10,19 @@ import {
 } from 'phosphor/lib/algorithm/searching';
 
 import {
+  ISequence
+} from 'phosphor/lib/algorithm/sequence';
+
+import {
+  Vector
+} from 'phosphor/lib/collections/vector';
+
+import {
   ISignal, clearSignalData, defineSignal
 } from 'phosphor/lib/core/signaling';
 
 import {
-  IKernel, Kernel, KernelMessage
+  Kernel, KernelMessage
 } from '../kernel';
 
 import {
@@ -25,7 +33,7 @@ import * as utils
   from '../utils';
 
 import {
-  ISession, Session
+  Session
 } from './session';
 
 import * as validate
@@ -44,17 +52,17 @@ const SESSION_SERVICE_URL = 'api/sessions';
  * all other operations, the kernel object should be used.
  */
 export
-class DefaultSession implements ISession {
+class DefaultSession implements Session.ISession {
   /**
    * Construct a new session.
    */
-  constructor(options: Session.IOptions, id: string, kernel: IKernel) {
+  constructor(options: Session.IOptions, id: string, kernel: Kernel.IKernel) {
     this.ajaxSettings = options.ajaxSettings || { };
     this._id = id;
     this._path = options.path;
     this._baseUrl = options.baseUrl || utils.getBaseUrl();
     this._uuid = utils.uuid();
-    Private.runningSessions[this._uuid] = this;
+    Private.runningSessions.pushBack(this);
     this.setupKernel(kernel);
     this._options = utils.copy(options);
   }
@@ -62,32 +70,32 @@ class DefaultSession implements ISession {
   /**
    * A signal emitted when the session dies.
    */
-  sessionDied: ISignal<ISession, void>;
+  sessionDied: ISignal<Session.ISession, void>;
 
   /**
    * A signal emitted when the kernel changes.
    */
-  kernelChanged: ISignal<ISession, IKernel>;
+  kernelChanged: ISignal<Session.ISession, Kernel.IKernel>;
 
   /**
    * A signal emitted when the kernel status changes.
    */
-  statusChanged: ISignal<ISession, Kernel.Status>;
+  statusChanged: ISignal<Session.ISession, Kernel.Status>;
 
   /**
    * A signal emitted for a kernel messages.
    */
-  iopubMessage: ISignal<ISession, KernelMessage.IMessage>;
+  iopubMessage: ISignal<Session.ISession, KernelMessage.IMessage>;
 
   /**
    * A signal emitted for an unhandled kernel message.
    */
-  unhandledMessage: ISignal<ISession, KernelMessage.IMessage>;
+  unhandledMessage: ISignal<Session.ISession, KernelMessage.IMessage>;
 
   /**
    * A signal emitted when the session path changes.
    */
-  pathChanged: ISignal<ISession, string>;
+  pathChanged: ISignal<Session.ISession, string>;
 
   /**
    * Get the session id.
@@ -104,7 +112,7 @@ class DefaultSession implements ISession {
    * Use the [statusChanged] and [unhandledMessage] signals on the session
    * instead of the ones on the kernel.
    */
-  get kernel() : IKernel {
+  get kernel() : Kernel.IKernel {
     return this._kernel;
   }
 
@@ -162,7 +170,7 @@ class DefaultSession implements ISession {
   /**
    * Clone the current session with a new clientId.
    */
-  clone(): Promise<ISession> {
+  clone(): Promise<Session.ISession> {
     let options = this._getKernelOptions();
     return Kernel.connectTo(this.kernel.id, options).then(kernel => {
       options = utils.copy(this._options);
@@ -206,7 +214,7 @@ class DefaultSession implements ISession {
     }
     this.sessionDied.emit(void 0);
     this._options = null;
-    delete Private.runningSessions[this._uuid];
+    Private.runningSessions.remove(this);
     this._kernel = null;
     clearSignalData(this);
   }
@@ -239,7 +247,7 @@ class DefaultSession implements ISession {
    * This shuts down the existing kernel and creates a new kernel,
    * keeping the existing session ID and session path.
    */
-  changeKernel(options: Kernel.IModel): Promise<IKernel> {
+  changeKernel(options: Kernel.IModel): Promise<Kernel.IKernel> {
     if (this.isDisposed) {
       return Promise.reject(new Error('Session is disposed'));
     }
@@ -269,7 +277,7 @@ class DefaultSession implements ISession {
   /**
    * Handle connections to a kernel.
    */
-  protected setupKernel(kernel: IKernel): void {
+  protected setupKernel(kernel: Kernel.IKernel): void {
     this._kernel = kernel;
     kernel.statusChanged.connect(this.onKernelStatus, this);
     kernel.unhandledMessage.connect(this.onUnhandledMessage, this);
@@ -279,21 +287,21 @@ class DefaultSession implements ISession {
   /**
    * Handle to changes in the Kernel status.
    */
-  protected onKernelStatus(sender: IKernel, state: Kernel.Status) {
+  protected onKernelStatus(sender: Kernel.IKernel, state: Kernel.Status) {
     this.statusChanged.emit(state);
   }
 
   /**
    * Handle iopub kernel messages.
    */
-  protected onIOPubMessage(sender: IKernel, msg: KernelMessage.IIOPubMessage) {
+  protected onIOPubMessage(sender: Kernel.IKernel, msg: KernelMessage.IIOPubMessage) {
     this.iopubMessage.emit(msg);
   }
 
   /**
    * Handle unhandled kernel messages.
    */
-  protected onUnhandledMessage(sender: IKernel, msg: KernelMessage.IMessage) {
+  protected onUnhandledMessage(sender: Kernel.IKernel, msg: KernelMessage.IMessage) {
     this.unhandledMessage.emit(msg);
   }
 
@@ -343,7 +351,7 @@ class DefaultSession implements ISession {
   private _id = '';
   private _path = '';
   private _ajaxSettings = '';
-  private _kernel: IKernel = null;
+  private _kernel: Kernel.IKernel = null;
   private _uuid = '';
   private _baseUrl = '';
   private _options: Session.IOptions = null;
@@ -369,7 +377,7 @@ namespace DefaultSession {
    * List the running sessions.
    */
   export
-  function listRunning(options?: Session.IOptions): Promise<IIterator<Session.IModel>> {
+  function listRunning(options?: Session.IOptions): Promise<ISequence<Session.IModel>> {
     return Private.listRunning(options);
   }
 
@@ -377,7 +385,7 @@ namespace DefaultSession {
    * Start a new session.
    */
   export
-  function startNew(options: Session.IOptions): Promise<ISession> {
+  function startNew(options: Session.IOptions): Promise<Session.ISession> {
     return Private.startNew(options);
   }
 
@@ -401,7 +409,7 @@ namespace DefaultSession {
    * Connect to a running session.
    */
   export
-  function connectTo(id: string, options?: Session.IOptions): Promise<ISession> {
+  function connectTo(id: string, options?: Session.IOptions): Promise<Session.ISession> {
     return Private.connectTo(id, options);
   }
 
@@ -423,13 +431,13 @@ namespace Private {
    * The running sessions.
    */
   export
-  const runningSessions: { [key: string]: DefaultSession; } = Object.create(null);
+  const runningSessions = new Vector<DefaultSession>();
 
   /**
    * List the running sessions.
    */
   export
-  function listRunning(options: Session.IOptions = {}): Promise<IIterator<Session.IModel>> {
+  function listRunning(options: Session.IOptions = {}): Promise<ISequence<Session.IModel>> {
     let baseUrl = options.baseUrl || utils.getBaseUrl();
     let url = utils.urlPathJoin(baseUrl, SESSION_SERVICE_URL);
     let ajaxSettings: IAjaxSettings = utils.copy(options.ajaxSettings || {});
@@ -441,17 +449,18 @@ namespace Private {
       if (success.xhr.status !== 200) {
         return utils.makeAjaxError(success);
       }
+      let data = success.data as Session.IModel[];
       if (!Array.isArray(success.data)) {
         return utils.makeAjaxError(success, 'Invalid Session list');
       }
-      for (let i = 0; i < success.data.length; i++) {
+      for (let i = 0; i < data.length; i++) {
         try {
-          validate.validateModel(success.data[i]);
+          validate.validateModel(data[i]);
         } catch (err) {
           return utils.makeAjaxError(success, err.message);
         }
       }
-      return updateRunningSessions(success.data);
+      return updateRunningSessions(new Vector(data));
     }, Private.onSessionError);
   }
 
@@ -459,7 +468,7 @@ namespace Private {
    * Start a new session.
    */
   export
-  function startNew(options: Session.IOptions): Promise<ISession> {
+  function startNew(options: Session.IOptions): Promise<Session.ISession> {
     if (options.path === void 0) {
       return Promise.reject(new Error('Must specify a path'));
     }
@@ -473,18 +482,11 @@ namespace Private {
    */
   export
   function findById(id: string, options: Session.IOptions = {}): Promise<Session.IModel> {
-    let sessions = runningSessions;
-    for (let clientId in sessions) {
-      let session = sessions[clientId];
-      if (session.id === id) {
-        let model: Session.IModel = {
-          id,
-          notebook: { path: session.path },
-          kernel: { name: session.kernel.name, id: session.kernel.id }
-        };
-        return Promise.resolve(model);
-      }
+    let session = find(runningSessions, value => value.id === id);
+    if (session) {
+      return Promise.resolve(session.model);
     }
+
     return getSessionModel(id, options).catch(() => {
       let msg = `No running session for id: ${id}`;
       return typedThrow<Session.IModel>(msg);
@@ -496,18 +498,11 @@ namespace Private {
    */
   export
   function findByPath(path: string, options: Session.IOptions = {}): Promise<Session.IModel> {
-    let sessions = runningSessions;
-    for (let clientId in sessions) {
-      let session = sessions[clientId];
-      if (session.path === path) {
-        let model: Session.IModel = {
-          id: session.id,
-          notebook: { path: session.path },
-          kernel: { name: session.kernel.name, id: session.kernel.id }
-        };
-        return Promise.resolve(model);
-      }
+    let session = find(runningSessions, value => value.path === path);
+    if (session) {
+      return Promise.resolve(session.model);
     }
+
     return listRunning(options).then(models => {
       let model = find(models, value => {
         return value.notebook.path === path;
@@ -524,18 +519,17 @@ namespace Private {
    * Connect to a running session.
    */
   export
-  function connectTo(id: string, options: Session.IOptions = {}): Promise<ISession> {
-    for (let clientId in runningSessions) {
-      let session = runningSessions[clientId];
-      if (session.id === id) {
-        return session.clone();
-      }
+  function connectTo(id: string, options: Session.IOptions = {}): Promise<Session.ISession> {
+    let session = find(runningSessions, value => value.id === id);
+    if (session) {
+      return Promise.resolve(session.clone());
     }
+
     return getSessionModel(id, options).then(model => {
       return createSession(model, options);
     }).catch(() => {
       let msg = `No running session with id: ${id}`;
-      return typedThrow<ISession>(msg);
+      return typedThrow<Session.ISession>(msg);
     });
   }
 
@@ -585,7 +579,7 @@ namespace Private {
   /**
    * Create a Promise for a kernel object given a session model and options.
    */
-  function createKernel(options: Session.IOptions): Promise<IKernel> {
+  function createKernel(options: Session.IOptions): Promise<Kernel.IKernel> {
     let kernelOptions: Kernel.IOptions = {
       name: options.kernelName,
       baseUrl: options.baseUrl || utils.getBaseUrl(),
@@ -645,24 +639,22 @@ namespace Private {
    * Update the running sessions based on new data from the server.
    */
   export
-  function updateRunningSessions(sessions: Session.IModel[]): Promise<IIterator<Session.IModel>> {
+  function updateRunningSessions(sessions: ISequence<Session.IModel>): Promise<ISequence<Session.IModel>> {
     let promises: Promise<void>[] = [];
-    for (let uuid in runningSessions) {
-      let session = runningSessions[uuid];
-      let updated = false;
-      for (let sId of sessions) {
+
+    each(runningSessions, session => {
+      let updated = find(sessions, sId => {
         if (session.id === sId.id) {
           promises.push(session.update(sId));
-          updated = true;
-          break;
+          return true;
         }
-      }
+      });
       // If session is no longer running on disk, emit dead signal.
       if (!updated && session.status !== 'dead') {
         session.sessionDied.emit(void 0);
       }
-    }
-    return Promise.all(promises).then(() => { return iter(sessions); });
+    });
+    return Promise.all(promises).then(() => { return sessions; });
   }
 
   /**
@@ -671,12 +663,11 @@ namespace Private {
   export
   function updateByModel(model: Session.IModel): Promise<Session.IModel> {
     let promises: Promise<void>[] = [];
-    for (let uuid in runningSessions) {
-      let session = runningSessions[uuid];
+    each(runningSessions, session => {
       if (session.id === model.id) {
         promises.push(session.update(model));
       }
-    }
+    });
     return Promise.all(promises).then(() => { return model; });
   }
 
@@ -694,12 +685,11 @@ namespace Private {
       if (success.xhr.status !== 204) {
         return utils.makeAjaxError(success);
       }
-      for (let uuid in runningSessions) {
-        let session = runningSessions[uuid];
+      each(toArray(runningSessions), session => {
         if (session.id === id) {
           session.dispose();
         }
-      }
+      });
     }, err => {
       if (err.xhr.status === 410) {
         err.throwError = 'The kernel was deleted but the session was not';

--- a/src/session/default.ts
+++ b/src/session/default.ts
@@ -10,10 +10,6 @@ import {
 } from 'phosphor/lib/algorithm/searching';
 
 import {
-  ISequence
-} from 'phosphor/lib/algorithm/sequence';
-
-import {
   Vector
 } from 'phosphor/lib/collections/vector';
 
@@ -377,7 +373,7 @@ namespace DefaultSession {
    * List the running sessions.
    */
   export
-  function listRunning(options?: Session.IOptions): Promise<ISequence<Session.IModel>> {
+  function listRunning(options?: Session.IOptions): Promise<Session.IModel[]> {
     return Private.listRunning(options);
   }
 
@@ -437,7 +433,7 @@ namespace Private {
    * List the running sessions.
    */
   export
-  function listRunning(options: Session.IOptions = {}): Promise<ISequence<Session.IModel>> {
+  function listRunning(options: Session.IOptions = {}): Promise<Session.IModel[]> {
     let baseUrl = options.baseUrl || utils.getBaseUrl();
     let url = utils.urlPathJoin(baseUrl, SESSION_SERVICE_URL);
     let ajaxSettings: IAjaxSettings = utils.copy(options.ajaxSettings || {});
@@ -460,7 +456,7 @@ namespace Private {
           return utils.makeAjaxError(success, err.message);
         }
       }
-      return updateRunningSessions(new Vector(data));
+      return updateRunningSessions(data);
     }, Private.onSessionError);
   }
 
@@ -639,7 +635,7 @@ namespace Private {
    * Update the running sessions based on new data from the server.
    */
   export
-  function updateRunningSessions(sessions: ISequence<Session.IModel>): Promise<ISequence<Session.IModel>> {
+  function updateRunningSessions(sessions: Session.IModel[]): Promise<Session.IModel[]> {
     let promises: Promise<void>[] = [];
 
     each(runningSessions, session => {

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  IIterator, iter, toArray
+  toArray
 } from 'phosphor/lib/algorithm/iteration';
 
 import {
@@ -12,10 +12,6 @@ import {
 import {
   ISequence
 } from 'phosphor/lib/algorithm/sequence';
-
-import {
-  Vector
-} from 'phosphor/lib/collections/vector';
 
 import {
   ISignal, clearSignalData, defineSignal
@@ -29,7 +25,7 @@ import * as utils
   from '../utils';
 
 import {
-  ISession, Session
+  Session
 } from './session';
 
 
@@ -96,14 +92,14 @@ class SessionManager implements Session.IManager {
    *
    * @param options - Overrides for the default options.
    */
-  listRunning(options?: Session.IOptions): Promise<IIterator<Session.IModel>> {
-    return Session.listRunning(this._getOptions(options)).then(it => {
-      let running = toArray(it);
-      if (!deepEqual(running, this._running)) {
-        this._running = running;
-        this.runningChanged.emit(new Vector(running));
+  listRunning(options?: Session.IOptions): Promise<ISequence<Session.IModel>> {
+    return Session.listRunning(this._getOptions(options)).then(running => {
+      let value = toArray(running);
+      if (!deepEqual(value, this._running)) {
+        this._running = value;
+        this.runningChanged.emit(running);
       }
-      return iter(running);
+      return running;
     });
   }
 
@@ -117,7 +113,7 @@ class SessionManager implements Session.IManager {
    * This will emit [[runningChanged]] if the running kernels list
    * changes.
    */
-  startNew(options: Session.IOptions): Promise<ISession> {
+  startNew(options: Session.IOptions): Promise<Session.ISession> {
     return Session.startNew(this._getOptions(options));
   }
 
@@ -138,7 +134,7 @@ class SessionManager implements Session.IManager {
   /*
    * Connect to a running session.  See also [[connectToSession]].
    */
-  connectTo(id: string, options?: Session.IOptions): Promise<ISession> {
+  connectTo(id: string, options?: Session.IOptions): Promise<Session.ISession> {
     return Session.connectTo(id, this._getOptions(options));
   }
 

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -2,16 +2,8 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  toArray
-} from 'phosphor/lib/algorithm/iteration';
-
-import {
   deepEqual
 } from 'phosphor/lib/algorithm/json';
-
-import {
-  ISequence
-} from 'phosphor/lib/algorithm/sequence';
 
 import {
   ISignal, clearSignalData, defineSignal
@@ -51,7 +43,7 @@ class SessionManager implements Session.IManager {
   /**
    * A signal emitted when the running sessions change.
    */
-  runningChanged: ISignal<SessionManager, ISequence<Session.IModel>>;
+  runningChanged: ISignal<SessionManager, Session.IModel[]>;
 
   /**
    * Test whether the terminal manager is disposed.
@@ -92,11 +84,10 @@ class SessionManager implements Session.IManager {
    *
    * @param options - Overrides for the default options.
    */
-  listRunning(options?: Session.IOptions): Promise<ISequence<Session.IModel>> {
+  listRunning(options?: Session.IOptions): Promise<Session.IModel[]> {
     return Session.listRunning(this._getOptions(options)).then(running => {
-      let value = toArray(running);
-      if (!deepEqual(value, this._running)) {
-        this._running = value;
+      if (!deepEqual(running, this._running)) {
+        this._running = running.slice();
         this.runningChanged.emit(running);
       }
       return running;

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -2,10 +2,6 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  IIterator
-} from 'phosphor/lib/algorithm/iteration';
-
-import {
   JSONObject
 } from 'phosphor/lib/algorithm/json';
 
@@ -22,7 +18,7 @@ import {
 } from 'phosphor/lib/core/signaling';
 
 import {
-  IKernel, Kernel, KernelMessage
+  Kernel, KernelMessage
 } from '../kernel';
 
 import {
@@ -35,116 +31,115 @@ import {
 
 
 /**
- * Interface of a session object.
- */
-export
-interface ISession extends IDisposable {
-  /**
-   * A signal emitted when the session is shut down.
-   */
-  sessionDied: ISignal<ISession, void>;
-
-  /**
-   * A signal emitted when the kernel changes.
-   */
-  kernelChanged: ISignal<ISession, IKernel>;
-
-  /**
-   * A signal emitted when the session status changes.
-   */
-  statusChanged: ISignal<ISession, Kernel.Status>;
-
-  /**
-   * A signal emitted when the session path changes.
-   */
-  pathChanged: ISignal<ISession, string>;
-
-  /**
-   * A signal emitted for iopub kernel messages.
-   */
-  iopubMessage: ISignal<ISession, KernelMessage.IIOPubMessage>;
-
-  /**
-   * A signal emitted for unhandled kernel message.
-   */
-  unhandledMessage: ISignal<ISession, KernelMessage.IMessage>;
-
-  /**
-   * Unique id of the session.
-   */
-  readonly id: string;
-
-  /**
-   * The path associated with the session.
-   */
-  readonly path: string;
-
-  /**
-   * The model associated with the session.
-   */
-  readonly model: Session.IModel;
-
-  /**
-   * The kernel.
-   *
-   * #### Notes
-   * This is a read-only property, and can be altered by [changeKernel].
-   * Use the [statusChanged] and [unhandledMessage] signals on the session
-   * instead of the ones on the kernel.
-   */
-  readonly kernel: IKernel;
-
-  /**
-   * The current status of the session.
-   *
-   * #### Notes
-   * This is a delegate to the kernel status.
-   */
-  readonly status: Kernel.Status;
-
-  /**
-   * Optional default settings for ajax requests, if applicable.
-   */
-  ajaxSettings?: IAjaxSettings;
-
-  /**
-   * Change the session path.
-   *
-   * @param path - The new session path.
-   *
-   * #### Notes
-   * This uses the Jupyter REST API, and the response is validated.
-   * The promise is fulfilled on a valid response and rejected otherwise.
-   */
-  rename(path: string): Promise<void>;
-
-  /**
-   * Change the kernel.
-   *
-   * @params options - The name or id of the new kernel.
-   *
-   * #### Notes
-   * This shuts down the existing kernel and creates a new kernel,
-   * keeping the existing session ID and path.
-   */
-  changeKernel(options: Kernel.IModel): Promise<IKernel>;
-
-  /**
-   * Kill the kernel and shutdown the session.
-   *
-   * #### Notes
-   * This uses the Jupyter REST API, and the response is validated.
-   * The promise is fulfilled on a valid response and rejected otherwise.
-   */
-  shutdown(): Promise<void>;
-}
-
-
-/**
  * A namespace for session interfaces and factory functions.
  */
 export
 namespace Session {
+  /**
+   * Interface of a session object.
+   */
+  export
+  interface ISession extends IDisposable {
+    /**
+     * A signal emitted when the session is shut down.
+     */
+    sessionDied: ISignal<ISession, void>;
+
+    /**
+     * A signal emitted when the kernel changes.
+     */
+    kernelChanged: ISignal<ISession, Kernel.IKernel>;
+
+    /**
+     * A signal emitted when the session status changes.
+     */
+    statusChanged: ISignal<ISession, Kernel.Status>;
+
+    /**
+     * A signal emitted when the session path changes.
+     */
+    pathChanged: ISignal<ISession, string>;
+
+    /**
+     * A signal emitted for iopub kernel messages.
+     */
+    iopubMessage: ISignal<ISession, KernelMessage.IIOPubMessage>;
+
+    /**
+     * A signal emitted for unhandled kernel message.
+     */
+    unhandledMessage: ISignal<ISession, KernelMessage.IMessage>;
+
+    /**
+     * Unique id of the session.
+     */
+    readonly id: string;
+
+    /**
+     * The path associated with the session.
+     */
+    readonly path: string;
+
+    /**
+     * The model associated with the session.
+     */
+    readonly model: Session.IModel;
+
+    /**
+     * The kernel.
+     *
+     * #### Notes
+     * This is a read-only property, and can be altered by [changeKernel].
+     * Use the [statusChanged] and [unhandledMessage] signals on the session
+     * instead of the ones on the kernel.
+     */
+    readonly kernel: Kernel.IKernel;
+
+    /**
+     * The current status of the session.
+     *
+     * #### Notes
+     * This is a delegate to the kernel status.
+     */
+    readonly status: Kernel.Status;
+
+    /**
+     * Optional default settings for ajax requests, if applicable.
+     */
+    ajaxSettings?: IAjaxSettings;
+
+    /**
+     * Change the session path.
+     *
+     * @param path - The new session path.
+     *
+     * #### Notes
+     * This uses the Jupyter REST API, and the response is validated.
+     * The promise is fulfilled on a valid response and rejected otherwise.
+     */
+    rename(path: string): Promise<void>;
+
+    /**
+     * Change the kernel.
+     *
+     * @params options - The name or id of the new kernel.
+     *
+     * #### Notes
+     * This shuts down the existing kernel and creates a new kernel,
+     * keeping the existing session ID and path.
+     */
+    changeKernel(options: Kernel.IModel): Promise<Kernel.IKernel>;
+
+    /**
+     * Kill the kernel and shutdown the session.
+     *
+     * #### Notes
+     * This uses the Jupyter REST API, and the response is validated.
+     * The promise is fulfilled on a valid response and rejected otherwise.
+     */
+    shutdown(): Promise<void>;
+  }
+
   /**
    * List the running sessions.
    *
@@ -156,7 +151,7 @@ namespace Session {
    * The promise is fulfilled on a valid response and rejected otherwise.
    */
   export
-  function listRunning(options?: Session.IOptions): Promise<IIterator<Session.IModel>> {
+  function listRunning(options?: Session.IOptions): Promise<ISequence<Session.IModel>> {
     return DefaultSession.listRunning(options);
   }
 
@@ -323,7 +318,7 @@ namespace Session {
      * This will emit a [[runningChanged]] signal if the value
      * has changed since the last fetch.
      */
-    listRunning(options?: IOptions): Promise<IIterator<IModel>>;
+    listRunning(options?: IOptions): Promise<ISequence<IModel>>;
 
     /**
      * Start a new session.

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -6,10 +6,6 @@ import {
 } from 'phosphor/lib/algorithm/json';
 
 import {
-  ISequence
-} from 'phosphor/lib/algorithm/sequence';
-
-import {
   IDisposable
 } from 'phosphor/lib/core/disposable';
 
@@ -151,7 +147,7 @@ namespace Session {
    * The promise is fulfilled on a valid response and rejected otherwise.
    */
   export
-  function listRunning(options?: Session.IOptions): Promise<ISequence<Session.IModel>> {
+  function listRunning(options?: Session.IOptions): Promise<Session.IModel[]> {
     return DefaultSession.listRunning(options);
   }
 
@@ -300,7 +296,7 @@ namespace Session {
     /**
      * A signal emitted when the running sessions change.
      */
-    runningChanged: ISignal<IManager, ISequence<IModel>>;
+    runningChanged: ISignal<IManager, IModel[]>;
 
     /**
      * Get the available kernel specs.
@@ -318,7 +314,7 @@ namespace Session {
      * This will emit a [[runningChanged]] signal if the value
      * has changed since the last fetch.
      */
-    listRunning(options?: IOptions): Promise<ISequence<IModel>>;
+    listRunning(options?: IOptions): Promise<IModel[]>;
 
     /**
      * Start a new session.

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -118,7 +118,7 @@ namespace Session {
     /**
      * Change the kernel.
      *
-     * @params options - The name or id of the new kernel.
+     * @param options - The name or id of the new kernel.
      *
      * #### Notes
      * This shuts down the existing kernel and creates a new kernel,

--- a/test/src/contents/index.spec.ts
+++ b/test/src/contents/index.spec.ts
@@ -543,8 +543,8 @@ describe('contents', () => {
         handler.respond(200, [DEFAULT_CP, DEFAULT_CP]);
       });
       let checkpoints = contents.listCheckpoints('/foo/bar.txt');
-      checkpoints.then(it => {
-        expect(it.next().last_modified).to.be(DEFAULT_CP.last_modified);
+      checkpoints.then(models => {
+        expect(models[0].last_modified).to.be(DEFAULT_CP.last_modified);
         done();
       });
     });
@@ -555,8 +555,8 @@ describe('contents', () => {
         handler.respond(200, [DEFAULT_CP, DEFAULT_CP]);
       });
       let checkpoints = contents.listCheckpoints('/foo/bar.txt');
-      checkpoints.then(it => {
-        expect(it.next().last_modified).to.be(DEFAULT_CP.last_modified);
+      checkpoints.then(models => {
+        expect(models[0].last_modified).to.be(DEFAULT_CP.last_modified);
         done();
       });
     });

--- a/test/src/integration.ts
+++ b/test/src/integration.ts
@@ -317,7 +317,7 @@ describe('jupyter.services - Integration', () => {
         checkpoint = value;
         return contents.listCheckpoints('baz.txt');
       }).then(checkpoints => {
-        expect(checkpoints.next()).to.eql(checkpoint);
+        expect(checkpoints[0]).to.eql(checkpoint);
         return contents.restoreCheckpoint('baz.txt', checkpoint.id);
       }).then(() => {
         return contents.deleteCheckpoint('baz.txt', checkpoint.id);
@@ -346,7 +346,7 @@ describe('jupyter.services - Integration', () => {
         return manager.listRunning();
       }).then(running => {
         expect(running.length).to.be(1);
-        return manager.shutdown(running.at(0).name);
+        return manager.shutdown(running[0].name);
       }).then(() => {
         return manager.listRunning();
       }).then(running => {

--- a/test/src/integration.ts
+++ b/test/src/integration.ts
@@ -345,13 +345,12 @@ describe('jupyter.services - Integration', () => {
       manager.create().then(session => {
         return manager.listRunning();
       }).then(running => {
-        let item = running.at(0);
         expect(running.length).to.be(1);
-        return manager.shutdown(item.name);
+        return manager.shutdown(running.at(0).name);
       }).then(() => {
         return manager.listRunning();
       }).then(running => {
-        expect(running.length).to.be(1);
+        expect(running.length).to.be(0);
         done();
       }).catch(done);
     });

--- a/test/src/integration.ts
+++ b/test/src/integration.ts
@@ -15,8 +15,8 @@ import {
 } from 'xmlhttprequest';
 
 import {
-  ConfigWithDefaults, ContentsManager, KernelMessage, Contents, IKernel,
-  ISession, TerminalManager, Session, Kernel,
+  ConfigWithDefaults, ContentsManager, KernelMessage, Contents,
+  TerminalManager, Session, Kernel,
   TerminalSession, ConfigSection
 } from '../../lib';
 
@@ -41,7 +41,7 @@ describe('jupyter.services - Integration', () => {
     });
 
     it('should interrupt and restart', (done) => {
-      let kernel: IKernel;
+      let kernel: Kernel.IKernel;
       Kernel.startNew().then(value => {
         kernel = value;
         return kernel.interrupt();
@@ -53,7 +53,7 @@ describe('jupyter.services - Integration', () => {
     });
 
     it('should get info', (done) => {
-      let kernel: IKernel;
+      let kernel: Kernel.IKernel;
       Kernel.startNew().then(value => {
         kernel = value;
         return kernel.kernelInfo();
@@ -63,8 +63,8 @@ describe('jupyter.services - Integration', () => {
     });
 
     it('should connect to existing kernel and list running kernels', (done) => {
-      let kernel: IKernel;
-      let kernel2: IKernel;
+      let kernel: Kernel.IKernel;
+      let kernel2: Kernel.IKernel;
       Kernel.startNew().then(value => {
         kernel = value;
         // should grab the same kernel object
@@ -79,7 +79,7 @@ describe('jupyter.services - Integration', () => {
         }
         return Kernel.listRunning();
       }).then(kernels => {
-        if (!kernels.next()) {
+        if (!kernels.length) {
           throw Error('Should be one at least one running kernel');
         }
         return kernel.shutdown();
@@ -87,7 +87,7 @@ describe('jupyter.services - Integration', () => {
     });
 
     it('should trigger a reconnect', (done) => {
-      let kernel: IKernel;
+      let kernel: Kernel.IKernel;
       Kernel.startNew().then(value => {
         kernel = value;
         return kernel.reconnect();
@@ -97,7 +97,7 @@ describe('jupyter.services - Integration', () => {
     });
 
     it('should handle other kernel messages', (done) => {
-      let kernel: IKernel;
+      let kernel: Kernel.IKernel;
       Kernel.startNew().then(value => {
         kernel = value;
         return kernel.complete({ code: 'impor', cursor_pos: 4 });
@@ -136,8 +136,8 @@ describe('jupyter.services - Integration', () => {
 
     it('should start, connect to existing session and list running sessions', (done) => {
       let options: Session.IOptions = { path: 'Untitled1.ipynb' };
-      let session: ISession;
-      let session2: ISession;
+      let session: Session.ISession;
+      let session2: Session.ISession;
       Session.startNew(options).then(value => {
         session = value;
         return session.rename('Untitled2.ipynb');
@@ -156,7 +156,7 @@ describe('jupyter.services - Integration', () => {
         }
         return Session.listRunning();
       }).then(sessions => {
-        if (!sessions.next()) {
+        if (!sessions.length) {
           throw Error('Should be one at least one running session');
         }
         return session.shutdown();
@@ -164,7 +164,7 @@ describe('jupyter.services - Integration', () => {
     });
 
     it('should connect to an existing kernel', (done) => {
-      let kernel: IKernel;
+      let kernel: Kernel.IKernel;
       Kernel.startNew().then(value => {
         kernel = value;
         let sessionOptions: Session.IOptions = {
@@ -179,8 +179,8 @@ describe('jupyter.services - Integration', () => {
     });
 
     it('should be able to switch to an existing kernel by id', (done) => {
-      let kernel: IKernel;
-      let session: ISession;
+      let kernel: Kernel.IKernel;
+      let session: Session.ISession;
       Kernel.startNew().then(value => {
         kernel = value;
         let sessionOptions: Session.IOptions = { path: 'Untitled1.ipynb' };
@@ -198,7 +198,7 @@ describe('jupyter.services - Integration', () => {
       // Get info about the available kernels and connect to one.
       let options: Session.IOptions = { path: 'Untitled1.ipynb' };
       let id: string;
-      let session: ISession;
+      let session: Session.ISession;
       Session.startNew(options).then(value => {
         session = value;
         id = session.kernel.id;
@@ -345,13 +345,13 @@ describe('jupyter.services - Integration', () => {
       manager.create().then(session => {
         return manager.listRunning();
       }).then(running => {
-        let item = running.next();
-        expect(running.next()).to.be(void 0);
+        let item = running.at(0);
+        expect(running.length).to.be(1);
         return manager.shutdown(item.name);
       }).then(() => {
         return manager.listRunning();
       }).then(running => {
-        expect(running.next()).to.be(void 0);
+        expect(running.length).to.be(1);
         done();
       }).catch(done);
     });

--- a/test/src/kernel/comm.spec.ts
+++ b/test/src/kernel/comm.spec.ts
@@ -7,7 +7,7 @@ import * as utils
   from '../../../lib/utils';
 
 import {
-  IKernel, KernelMessage, Kernel
+  KernelMessage, Kernel
 } from '../../../lib/kernel';
 
 import {
@@ -18,7 +18,7 @@ import {
 describe('jupyter.services - Comm', () => {
 
   let tester: KernelTester;
-  let kernel: IKernel;
+  let kernel: Kernel.IKernel;
 
   beforeEach((done) => {
     tester = new KernelTester();
@@ -398,7 +398,7 @@ describe('jupyter.services - Comm', () => {
 });
 
 
-function sendCommMessage(tester: KernelTester, kernel: IKernel, msgType: string, content: any) {
+function sendCommMessage(tester: KernelTester, kernel: Kernel.IKernel, msgType: string, content: any) {
   let options: KernelMessage.IOptions = {
     msgType: msgType,
     channel: 'iopub',

--- a/test/src/kernel/kernel.spec.ts
+++ b/test/src/kernel/kernel.spec.ts
@@ -16,7 +16,7 @@ import {
 } from '../../../lib/utils';
 
 import {
-  IKernel, KernelManager, Kernel, KernelMessage
+  KernelManager, Kernel, KernelMessage
 } from '../../../lib/kernel';
 
 import {
@@ -47,7 +47,7 @@ let createMsg = (channel: KernelMessage.Channel, parentHeader: JSONObject): Kern
 describe('kernel', () => {
 
   let tester: KernelTester;
-  let kernel: IKernel;
+  let kernel: Kernel.IKernel;
 
   beforeEach(() => {
     tester = new KernelTester();
@@ -130,7 +130,7 @@ describe('kernel', () => {
 
   describe('Kernel.startNew()', () => {
 
-    it('should create an IKernel object', (done) => {
+    it('should create an Kernel.IKernel object', (done) => {
       Kernel.startNew(KERNEL_OPTIONS).then(k => {
         kernel = k;
         expect(kernel.status).to.be('unknown');
@@ -299,7 +299,7 @@ describe('kernel', () => {
 
   });
 
-  describe('IKernel', () => {
+  describe('Kernel.IKernel', () => {
 
     beforeEach((done) => {
       Kernel.startNew().then(k => {
@@ -823,7 +823,7 @@ describe('kernel', () => {
       });
 
       it('should dispose of all kernel instances', (done) => {
-        let kernel2: IKernel;
+        let kernel2: Kernel.IKernel;
         Kernel.connectTo(kernel.id).then(k => {
           kernel2 = k;
           tester.onRequest = () => {

--- a/test/src/kernel/manager.spec.ts
+++ b/test/src/kernel/manager.spec.ts
@@ -16,7 +16,7 @@ import {
 } from '../../../lib/utils';
 
 import {
-  KernelManager, Kernel, IKernel
+  KernelManager, Kernel
 } from '../../../lib/kernel';
 
 import {
@@ -33,7 +33,7 @@ PYTHON3_SPEC.spec.display_name = 'python3';
 describe('kernel/manager', () => {
 
   let tester: KernelTester;
-  let kernel: IKernel;
+  let kernel: Kernel.IKernel;
 
   beforeEach(() => {
     tester = new KernelTester();

--- a/test/src/session/manager.spec.ts
+++ b/test/src/session/manager.spec.ts
@@ -16,7 +16,7 @@ import {
 } from '../../../lib/utils';
 
 import {
-  SessionManager, Session, ISession
+  SessionManager, Session
 } from '../../../lib/session';
 
 import {
@@ -53,7 +53,7 @@ function createSessionOptions(sessionModel?: Session.IModel): Session.IOptions {
 describe('session', () => {
 
   let tester: KernelTester;
-  let session: ISession;
+  let session: Session.ISession;
 
   beforeEach(() => {
     tester = new KernelTester();

--- a/test/src/session/session.spec.ts
+++ b/test/src/session/session.spec.ts
@@ -16,7 +16,7 @@ import {
 } from '../../../lib/kernel';
 
 import {
-  ISession, Session
+  Session
 } from '../../../lib/session';
 
 import {
@@ -50,7 +50,7 @@ function createSessionOptions(sessionModel?: Session.IModel): Session.IOptions {
 }
 
 
-function startNewSession(tester?: KernelTester): Promise<ISession> {
+function startNewSession(tester?: KernelTester): Promise<Session.ISession> {
   tester = tester || new KernelTester();
   let sessionModel = createSessionModel();
   tester.onRequest = request => {
@@ -68,7 +68,7 @@ function startNewSession(tester?: KernelTester): Promise<ISession> {
 describe('session', () => {
 
   let tester: KernelTester;
-  let session: ISession;
+  let session: Session.ISession;
 
   beforeEach(() => {
     tester = new KernelTester();
@@ -417,7 +417,7 @@ describe('session', () => {
   });
 
 
-  describe('ISession', () => {
+  describe('Session.ISession', () => {
 
 
     beforeEach((done) => {
@@ -806,7 +806,7 @@ describe('session', () => {
       });
 
       it('should dispose of all session instances', (done) => {
-        let session2: ISession;
+        let session2: Session.ISession;
         Session.connectTo(session.id).then(s => {
           session2 = s;
           tester.onRequest = () => {

--- a/test/src/terminal/terminal.spec.ts
+++ b/test/src/terminal/terminal.spec.ts
@@ -16,7 +16,7 @@ import {
 } from 'phosphor/lib/collections/vector';
 
 import {
-  TerminalSession, TerminalManager, ITerminalSession
+  TerminalSession, TerminalManager
 } from '../../../lib/terminal';
 
 import {
@@ -27,7 +27,7 @@ import {
 describe('terminals', () => {
 
   let tester: TerminalTester;
-  let session: ITerminalSession;
+  let session: TerminalSession.ISession;
 
   beforeEach(() => {
     tester = new TerminalTester();
@@ -151,7 +151,7 @@ describe('terminals', () => {
 
   });
 
-  describe('ITerminalSession', () => {
+  describe('TerminalSession.ISession', () => {
 
     beforeEach((done) => {
       TerminalSession.open().then(s => {

--- a/test/src/terminal/terminal.spec.ts
+++ b/test/src/terminal/terminal.spec.ts
@@ -12,10 +12,6 @@ import {
 } from 'phosphor/lib/algorithm/json';
 
 import {
-  Vector
-} from 'phosphor/lib/collections/vector';
-
-import {
   TerminalSession, TerminalManager
 } from '../../../lib/terminal';
 
@@ -219,7 +215,7 @@ describe('terminals', () => {
           expect(msg.type).to.be('stdin');
           done();
         });
-        session.send({ type: 'stdin', content: new Vector([1, 2]) });
+        session.send({ type: 'stdin', content: [1, 2] });
       });
 
     });

--- a/test/src/testmanager.ts
+++ b/test/src/testmanager.ts
@@ -13,7 +13,7 @@ import {
 } from 'phosphor/lib/algorithm/json';
 
 import {
-  IServiceManager, ServiceManager
+  ServiceManager
 } from '../../lib/manager';
 
 import {
@@ -62,7 +62,7 @@ describe('manager', () => {
 
   describe('SessionManager', () => {
 
-    let manager: IServiceManager;
+    let manager: ServiceManager.IManager;
 
     beforeEach((done) => {
       let handler = new RequestHandler(() => {

--- a/test/src/utils.ts
+++ b/test/src/utils.ts
@@ -7,10 +7,6 @@ import {
   JSONPrimitive
 } from 'phosphor/lib/algorithm/json';
 
-import {
-  Vector
-} from 'phosphor/lib/collections/vector';
-
 import * as WebSocket
   from  'ws';
 
@@ -370,7 +366,7 @@ class TerminalTester extends RequestSocketTester {
         let data = JSON.parse(msg) as JSONPrimitive[];
         let termMsg: TerminalSession.IMessage = {
           type: data[0] as TerminalSession.MessageType,
-          content: new Vector(data.slice(1))
+          content: data.slice(1)
         };
         onMessage(termMsg);
       }


### PR DESCRIPTION
Switch back to arrays.
Move the top level interfaces into namespaces.