### PR TITLE
Move nbformat into services

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export * from './config';
 export * from './contents';
 export * from './kernel';
 export * from './manager';
+export * from './nbformat';
 export * from './session';
 export * from './terminal';
 

--- a/src/kernel/messages.ts
+++ b/src/kernel/messages.ts
@@ -121,7 +121,6 @@ namespace KernelMessage {
   export
   interface IStreamMsg extends IIOPubMessage {
     content: {
-      [ key: string ]: JSONValue;
       name: 'stdout' | 'stderr';
       text: string;
     };
@@ -143,10 +142,8 @@ namespace KernelMessage {
   export
   interface IDisplayDataMsg extends IIOPubMessage {
     content: {
-      [ key: string ]: JSONValue;
-      source: string;
-      data: { [key: string]: string };
-      metadata: JSONObject;
+      data: nbformat.IMimeBundle,
+      metadata: nbformat.OutputMetadata;
     };
   }
 
@@ -166,9 +163,8 @@ namespace KernelMessage {
   export
   interface IExecuteInputMsg extends IIOPubMessage {
     content: {
-      [ key: string ]: JSONValue;
       code: string;
-      execution_count: number;
+      execution_count: nbformat.ExecutionCount;
     };
   }
 
@@ -188,10 +184,9 @@ namespace KernelMessage {
   export
   interface IExecuteResultMsg extends IIOPubMessage {
     content: {
-      [ key: string ]: JSONValue;
-      execution_count: number;
-      data: { [key: string]: string };
-      metadata: JSONObject;
+      execution_count: nbformat.ExecutionCount;
+      data: nbformat.IMimeBundle,
+      metadata: nbformat.OutputMetadata;
     };
   }
 
@@ -211,8 +206,6 @@ namespace KernelMessage {
   export
   interface IErrorMsg extends IIOPubMessage {
     content: {
-      [ key: string ]: JSONValue;
-      execution_count: number;
       ename: string;
       evalue: string;
       traceback: string[];
@@ -235,7 +228,6 @@ namespace KernelMessage {
   export
   interface IStatusMsg extends IIOPubMessage {
     content: {
-      [ key: string ]: JSONValue;
       execution_state: Kernel.Status;
     };
   }
@@ -256,7 +248,6 @@ namespace KernelMessage {
   export
   interface IClearOutputMsg extends IIOPubMessage {
     content: {
-      [ key: string ]: JSONValue;
       wait: boolean;
     };
   }
@@ -287,7 +278,6 @@ namespace KernelMessage {
    */
   export
   interface ICommOpen extends JSONObject {
-    [ key: string ]: JSONValue;
     comm_id: string;
     target_name: string;
     data: JSONValue;
@@ -320,7 +310,6 @@ namespace KernelMessage {
    */
    export
    interface ICommClose extends JSONObject {
-      [ key: string ]: JSONValue;
       comm_id: string;
       data: JSONValue;
    }
@@ -351,7 +340,6 @@ namespace KernelMessage {
    */
   export
   interface ICommMsg extends JSONObject {
-    [ key: string ]: JSONValue;
     comm_id: string;
     data: JSONValue;
   }
@@ -381,7 +369,6 @@ namespace KernelMessage {
    */
   export
   interface IInfoReply extends JSONObject {
-    [ key: string ]: JSONValue;
     protocol_version: string;
     implementation: string;
     implementation_version: string;
@@ -397,7 +384,6 @@ namespace KernelMessage {
    */
   export
   interface ILanguageInfo extends nbformat.ILanguageInfoMetadata {
-    [ key: string ]: JSONValue;
     version: string;
     nbconverter_exporter?: string;
   }
@@ -411,7 +397,6 @@ namespace KernelMessage {
    */
   export
   interface ICompleteRequest extends JSONObject {
-    [ key: string ]: JSONValue;
     code: string;
     cursor_pos: number;
   }
@@ -426,7 +411,6 @@ namespace KernelMessage {
   export
   interface ICompleteReplyMsg extends IShellMessage {
     content: {
-      [ key: string ]: JSONValue;
       matches: string[];
       cursor_start: number;
       cursor_end: number;
@@ -444,10 +428,9 @@ namespace KernelMessage {
    */
   export
   interface IInspectRequest extends JSONObject {
-    [ key: string ]: JSONValue;
     code: string;
     cursor_pos: number;
-    detail_level: number;
+    detail_level: 0 | 1;
   }
 
   /**
@@ -460,8 +443,7 @@ namespace KernelMessage {
   export
   interface IInspectReplyMsg extends IShellMessage {
     content: {
-      [ key: string ]: JSONValue;
-      status: string;
+      status: 'ok' | 'error';
       found: boolean;
       data: JSONObject;
       metadata: JSONObject;
@@ -477,7 +459,6 @@ namespace KernelMessage {
    */
   export
   interface IHistoryRequest extends JSONObject {
-    [ key: string ]: JSONValue;
     output: boolean;
     raw: boolean;
     hist_access_type: HistAccess;
@@ -499,7 +480,6 @@ namespace KernelMessage {
   export
   interface IHistoryReplyMsg extends IShellMessage {
     content: {
-      [ key: string ]: JSONValue;
       history: JSONValue[];
     };
   }
@@ -519,7 +499,6 @@ namespace KernelMessage {
    */
   export
   interface IIsCompleteRequest extends JSONObject {
-    [ key: string ]: JSONValue;
     code: string;
   }
 
@@ -533,7 +512,6 @@ namespace KernelMessage {
   export
   interface IIsCompleteReplyMsg extends IShellMessage {
     content: {
-      [ key: string ]: JSONValue;
       status: string;
       indent: string;
     };
@@ -558,8 +536,6 @@ namespace KernelMessage {
    */
   export
   interface IExecuteOptions extends JSONObject {
-    [ key: string ]: JSONValue;
-
     /**
      * Whether to execute the code as quietly as possible.
      * The default is `false`.
@@ -612,7 +588,7 @@ namespace KernelMessage {
   export
   interface IExecuteReply extends JSONObject {
     status: 'ok' | 'error' | 'abort';
-    execution_count: number;
+    execution_count: nbformat.ExecutionCount;
   }
 
   /**
@@ -715,7 +691,6 @@ namespace KernelMessage {
    */
   export
   interface ICommInfoRequest extends JSONObject {
-    [ key: string ]: JSONValue;
     target?: string;
   }
 
@@ -729,7 +704,6 @@ namespace KernelMessage {
   export
   interface ICommInfoReplyMsg extends IShellMessage {
     content: {
-      [ key: string ]: JSONValue;
       /**
        * Mapping of comm ids to target names.
        */
@@ -744,7 +718,6 @@ namespace KernelMessage {
    */
   export
   interface IOptions {
-    [ key: string ]: JSONValue;
     msgType: string;
     channel: Channel;
     session: string;

--- a/src/kernel/messages.ts
+++ b/src/kernel/messages.ts
@@ -5,6 +5,10 @@ import {
   JSONObject, JSONValue
 } from 'phosphor/lib/algorithm/json';
 
+import {
+  nbformat
+} from '../nbformat';
+
 import * as utils
  from '../utils';
 
@@ -392,14 +396,9 @@ namespace KernelMessage {
    * See [Messaging in Jupyter](https://jupyter-client.readthedocs.io/en/latest/messaging.html#kernel-info).
    */
   export
-  interface ILanguageInfo {
+  interface ILanguageInfo extends nbformat.ILanguageInfoMetadata {
     [ key: string ]: JSONValue;
-    name: string;
     version: string;
-    mimetype: string;
-    file_extension: string;
-    pygments_lexer?: string;
-    codemirror_mode?: string | JSONObject;
     nbconverter_exporter?: string;
   }
 

--- a/src/nbformat.ts
+++ b/src/nbformat.ts
@@ -79,7 +79,7 @@ namespace nbformat {
    * A mime-type keyed dictionary of data.
    */
   export
-  interface IIMimeBundle extends JSONObject {
+  interface IMimeBundle extends JSONObject {
     [key: string]: MultilineString | JSONObject;
   }
 
@@ -96,7 +96,7 @@ namespace nbformat {
    * The code cell's prompt number. Will be null if the cell has not been run.
    */
   export
-  type ExecutionCount = number | null.
+  type ExecutionCount = number | null;
 
   /**
    * Cell output metadata.

--- a/src/nbformat.ts
+++ b/src/nbformat.ts
@@ -84,8 +84,7 @@ namespace nbformat {
   }
 
   /**
-   * Media attachments (e.g. inline images), stored as mimebundle keyed
-   * by filename.
+   * Media attachments (e.g. inline images).
    */
   export
   interface IAttachments {

--- a/src/nbformat.ts
+++ b/src/nbformat.ts
@@ -88,7 +88,7 @@ namespace nbformat {
    */
   export
   interface IAttachments {
-    [key: string]: IIMimeBundle;
+    [key: string]: IMimeBundle;
   }
 
   /**

--- a/src/nbformat.ts
+++ b/src/nbformat.ts
@@ -11,7 +11,7 @@ import {
 
 
 /**
- * A namespace for the notebook format.
+ * A namespace for nbformat interfaces.
  */
 export
 namespace nbformat {
@@ -25,7 +25,7 @@ namespace nbformat {
    * The minor version of the notebook format.
    */
   export
-  const MINOR_VERSION = 0;
+  const MINOR_VERSION = 1;
 
   /**
    * The kernelspec metadata.
@@ -48,17 +48,15 @@ namespace nbformat {
     pygments_lexer?: string;
   }
 
-
   /**
    * The default metadata for the notebook.
    */
   export
   interface INotebookMetadata extends JSONObject {
-    kernelspec: IKernelspecMetadata;
-    language_info: ILanguageInfoMetadata;
-    orig_nbformat: number;
+    kernelspec?: IKernelspecMetadata;
+    language_info?: ILanguageInfoMetadata;
+    orig_nbformat?: number;
   }
-
 
   /**
    * The notebook content.
@@ -71,27 +69,40 @@ namespace nbformat {
     cells: ICell[];
   }
 
-
   /**
-   * A type alias for a multiline string.
-   *
-   * #### Notes
-   * On disk, this could be a string[] too.
+   * A multiline string.
    */
   export
-  type multilineString = string | string[];
+  type MultilineString = string | string[];
 
-
-  /* tslint:disable */
   /**
    * A mime-type keyed dictionary of data.
    */
   export
-  interface MimeBundle extends JSONObject {
-    [key: string]: multilineString | JSONObject;
+  interface IIMimeBundle extends JSONObject {
+    [key: string]: MultilineString | JSONObject;
   }
-  /* tslint:enable */
 
+  /**
+   * Media attachments (e.g. inline images), stored as mimebundle keyed
+   * by filename.
+   */
+  export
+  interface IAttachments {
+    [key: string]: IIMimeBundle;
+  }
+
+  /**
+   * The code cell's prompt number. Will be null if the cell has not been run.
+   */
+  export
+  type ExecutionCount = number | null.
+
+  /**
+   * Cell output metadata.
+   */
+  export
+  type OutputMetadata = JSONObject;
 
   /**
    * Validate a mime type/value pair.
@@ -103,7 +114,7 @@ namespace nbformat {
    * @returns Whether the type/value pair are valid.
    */
   export
-  function validateMimeValue(type: string, value: multilineString | JSONObject): boolean {
+  function validateMimeValue(type: string, value: MultilineString | JSONObject): boolean {
     // Check if "application/json" or "application/foo+json"
     const jsonTest = /^application\/(.*?)+\+json$/;
     const isJSONType = type === 'application/json' || jsonTest.test(type);
@@ -141,13 +152,11 @@ namespace nbformat {
     return isObject(value);
   }
 
-
   /**
    * A type which describes the type of cell.
    */
   export
   type CellType = 'code' | 'markdown' | 'raw';
-
 
   /**
    * Cell-level metadata.
@@ -176,7 +185,6 @@ namespace nbformat {
     tags?: string[];
   }
 
-
   /**
    * The base cell interface.
    */
@@ -190,14 +198,13 @@ namespace nbformat {
     /**
      * Contents of the cell, represented as an array of lines.
      */
-    source: multilineString;
+    source: MultilineString;
 
     /**
      * Cell-level metadata.
      */
     metadata: ICellMetadata;
   }
-
 
   /**
    * Metadata for the raw cell.
@@ -208,8 +215,12 @@ namespace nbformat {
      * Raw cell metadata format for nbconvert.
      */
     format?: string;
-  }
 
+    /**
+     * Media attachments (e.g. inline images).
+     */
+    attachments?: IAttachments;
+  }
 
   /**
    * A raw cell.
@@ -227,7 +238,6 @@ namespace nbformat {
     metadata: IRawCellMetadata;
   }
 
-
   /**
    * A markdown cell.
    */
@@ -238,7 +248,6 @@ namespace nbformat {
      */
     cell_type: 'markdown';
   }
-
 
   /**
    * Metadata for a code cell.
@@ -254,8 +263,12 @@ namespace nbformat {
      * Whether the cell's output is scrolled, unscrolled, or autoscrolled.
      */
     scrolled?: boolean | 'auto';
-  }
 
+    /**
+     * Media attachments (e.g. inline images).
+     */
+    attachments?: IAttachments;
+  }
 
   /**
    * A code cell.
@@ -280,9 +293,8 @@ namespace nbformat {
     /**
      * The code cell's prompt number. Will be null if the cell has not been run.
      */
-    execution_count: number;
+    execution_count: ExecutionCount;
   }
-
 
   /**
    * A cell union type.
@@ -297,13 +309,11 @@ namespace nbformat {
   export
   type ICellMetadata = IBaseCellMetadata | IRawCellMetadata | ICodeCellMetadata;
 
-
   /**
    * The valid output types.
    */
   export
   type OutputType = 'execute_result' | 'display_data' | 'stream' | 'error';
-
 
   /**
    * The base output type.
@@ -315,7 +325,6 @@ namespace nbformat {
      */
     output_type: OutputType;
   }
-
 
   /**
    * Result of executing a code cell.
@@ -330,19 +339,18 @@ namespace nbformat {
     /**
      * A result's prompt number.
      */
-    execution_count: number;
+    execution_count: ExecutionCount;
 
     /**
      * A mime-type keyed dictionary of data.
      */
-    data: MimeBundle;
+    data: IMimeBundle;
 
     /**
      * Cell output metadata.
      */
-    metadata: JSONObject;
+    metadata: OutputMetadata;
   }
-
 
   /**
    * Data displayed as a result of code cell execution.
@@ -357,14 +365,13 @@ namespace nbformat {
     /**
      * A mime-type keyed dictionary of data.
      */
-    data: MimeBundle;
+    data: IMimeBundle;
 
     /**
      * Cell output metadata.
      */
-    metadata: JSONObject;
+    metadata: OutputMetadata;
   }
-
 
   /**
    * Stream output from a code cell.
@@ -384,9 +391,8 @@ namespace nbformat {
     /**
      * The stream's text output.
      */
-    text: multilineString;
+    text: MultilineString;
   }
-
 
   /**
    * Output of an error that occurred during code cell execution.
@@ -413,7 +419,6 @@ namespace nbformat {
      */
     traceback: string[];
   }
-
 
   /**
    * An output union type.

--- a/src/nbformat.ts
+++ b/src/nbformat.ts
@@ -1,0 +1,423 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+// Notebook format interfaces
+// https://nbformat.readthedocs.io/en/latest/format_description.html
+// https://github.com/jupyter/nbformat/blob/master/nbformat/v4/nbformat.v4.schema.json
+
+import {
+  JSONObject, isObject
+} from 'phosphor/lib/algorithm/json';
+
+
+/**
+ * A namespace for the notebook format.
+ */
+export
+namespace nbformat {
+  /**
+   * The major version of the notebook format.
+   */
+  export
+  const MAJOR_VERSION = 4;
+
+  /**
+   * The minor version of the notebook format.
+   */
+  export
+  const MINOR_VERSION = 0;
+
+  /**
+   * The kernelspec metadata.
+   */
+  export
+  interface IKernelspecMetadata extends JSONObject {
+    name: string;
+    display_name: string;
+  }
+
+  /**
+   * The language info metatda
+   */
+  export
+  interface ILanguageInfoMetadata extends JSONObject {
+    name: string;
+    codemirror_mode?: string | JSONObject;
+    file_extension?: string;
+    mimetype?: string;
+    pygments_lexer?: string;
+  }
+
+
+  /**
+   * The default metadata for the notebook.
+   */
+  export
+  interface INotebookMetadata extends JSONObject {
+    kernelspec: IKernelspecMetadata;
+    language_info: ILanguageInfoMetadata;
+    orig_nbformat: number;
+  }
+
+
+  /**
+   * The notebook content.
+   */
+  export
+  interface INotebookContent extends JSONObject {
+    metadata: INotebookMetadata;
+    nbformat_minor: number;
+    nbformat: number;
+    cells: ICell[];
+  }
+
+
+  /**
+   * A type alias for a multiline string.
+   *
+   * #### Notes
+   * On disk, this could be a string[] too.
+   */
+  export
+  type multilineString = string | string[];
+
+
+  /* tslint:disable */
+  /**
+   * A mime-type keyed dictionary of data.
+   */
+  export
+  interface MimeBundle extends JSONObject {
+    [key: string]: multilineString | JSONObject;
+  }
+  /* tslint:enable */
+
+
+  /**
+   * Validate a mime type/value pair.
+   *
+   * @param type - The mimetype name.
+   *
+   * @param value - The value associated with the type.
+   *
+   * @returns Whether the type/value pair are valid.
+   */
+  export
+  function validateMimeValue(type: string, value: multilineString | JSONObject): boolean {
+    // Check if "application/json" or "application/foo+json"
+    const jsonTest = /^application\/(.*?)+\+json$/;
+    const isJSONType = type === 'application/json' || jsonTest.test(type);
+
+    let isString = (x: any) => {
+      return Object.prototype.toString.call(x) === '[object String]';
+    };
+
+    // If it is an array, make sure if is not a JSON type and it is an
+    // array of strings.
+    if (Array.isArray(value)) {
+      if (isJSONType) {
+        return false;
+      }
+      let valid = true;
+      (value as string[]).forEach(v => {
+        if (!isString(v)) {
+          valid = false;
+        }
+      });
+      return valid;
+    }
+
+    // If it is a string, make sure we are not a JSON type.
+    if (isString(value)) {
+      return !isJSONType;
+    }
+
+    // It is not a string, make sure it is a JSON type.
+    if (!isJSONType) {
+      return false;
+    }
+
+    // It is a JSON type, make sure it is a valid JSON object.
+    return isObject(value);
+  }
+
+
+  /**
+   * A type which describes the type of cell.
+   */
+  export
+  type CellType = 'code' | 'markdown' | 'raw';
+
+
+  /**
+   * Cell-level metadata.
+   */
+  export
+  interface IBaseCellMetadata extends JSONObject {
+    /**
+     * Whether the cell is trusted.
+     *
+     * #### Notes
+     * This is not strictly part of the nbformat spec, but it is added by
+     * the contents manager.
+     *
+     * See https://jupyter-notebook.readthedocs.io/en/latest/security.html.
+     */
+    trusted: boolean;
+
+    /**
+     * The cell's name. If present, must be a non-empty string.
+     */
+    name?: string;
+
+    /**
+     * The cell's tags. Tags must be unique, and must not contain commas.
+     */
+    tags?: string[];
+  }
+
+
+  /**
+   * The base cell interface.
+   */
+  export
+  interface IBaseCell extends JSONObject {
+    /**
+     * String identifying the type of cell.
+     */
+    cell_type: CellType;
+
+    /**
+     * Contents of the cell, represented as an array of lines.
+     */
+    source: multilineString;
+
+    /**
+     * Cell-level metadata.
+     */
+    metadata: ICellMetadata;
+  }
+
+
+  /**
+   * Metadata for the raw cell.
+   */
+  export
+  interface IRawCellMetadata extends IBaseCellMetadata {
+    /**
+     * Raw cell metadata format for nbconvert.
+     */
+    format?: string;
+  }
+
+
+  /**
+   * A raw cell.
+   */
+  export
+  interface IRawCell extends IBaseCell {
+    /**
+     * String identifying the type of cell.
+     */
+    cell_type: 'raw';
+
+    /**
+     * Cell-level metadata.
+     */
+    metadata: IRawCellMetadata;
+  }
+
+
+  /**
+   * A markdown cell.
+   */
+  export
+  interface IMarkdownCell extends IBaseCell {
+    /**
+     * String identifying the type of cell.
+     */
+    cell_type: 'markdown';
+  }
+
+
+  /**
+   * Metadata for a code cell.
+   */
+  export
+  interface ICodeCellMetadata extends IBaseCellMetadata {
+    /**
+     * Whether the cell is collapsed/expanded.
+     */
+    collapsed?: boolean;
+
+    /**
+     * Whether the cell's output is scrolled, unscrolled, or autoscrolled.
+     */
+    scrolled?: boolean | 'auto';
+  }
+
+
+  /**
+   * A code cell.
+   */
+  export
+  interface ICodeCell extends IBaseCell {
+    /**
+     * String identifying the type of cell.
+     */
+    cell_type: 'code';
+
+    /**
+     * Cell-level metadata.
+     */
+    metadata: ICodeCellMetadata;
+
+    /**
+     * Execution, display, or stream outputs.
+     */
+    outputs: IOutput[];
+
+    /**
+     * The code cell's prompt number. Will be null if the cell has not been run.
+     */
+    execution_count: number;
+  }
+
+
+  /**
+   * A cell union type.
+   */
+  export
+  type ICell = IRawCell | IMarkdownCell | ICodeCell;
+
+
+  /**
+   * A union metadata type.
+   */
+  export
+  type ICellMetadata = IBaseCellMetadata | IRawCellMetadata | ICodeCellMetadata;
+
+
+  /**
+   * The valid output types.
+   */
+  export
+  type OutputType = 'execute_result' | 'display_data' | 'stream' | 'error';
+
+
+  /**
+   * The base output type.
+   */
+  export
+  interface IBaseOutput extends JSONObject {
+    /**
+     * Type of cell output.
+     */
+    output_type: OutputType;
+  }
+
+
+  /**
+   * Result of executing a code cell.
+   */
+  export
+  interface IExecuteResult extends IBaseOutput {
+    /**
+     * Type of cell output.
+     */
+    output_type: 'execute_result';
+
+    /**
+     * A result's prompt number.
+     */
+    execution_count: number;
+
+    /**
+     * A mime-type keyed dictionary of data.
+     */
+    data: MimeBundle;
+
+    /**
+     * Cell output metadata.
+     */
+    metadata: JSONObject;
+  }
+
+
+  /**
+   * Data displayed as a result of code cell execution.
+   */
+  export
+  interface IDisplayData extends IBaseOutput {
+    /**
+     * Type of cell output.
+     */
+    output_type: 'display_data';
+
+    /**
+     * A mime-type keyed dictionary of data.
+     */
+    data: MimeBundle;
+
+    /**
+     * Cell output metadata.
+     */
+    metadata: JSONObject;
+  }
+
+
+  /**
+   * Stream output from a code cell.
+   */
+  export
+  interface IStream extends IBaseOutput {
+    /**
+     * Type of cell output.
+     */
+    output_type: 'stream';
+
+    /**
+     * The name of the stream.
+     */
+    name: 'stdout' | 'stderr';
+
+    /**
+     * The stream's text output.
+     */
+    text: multilineString;
+  }
+
+
+  /**
+   * Output of an error that occurred during code cell execution.
+   */
+  export
+  interface IError extends IBaseOutput {
+    /**
+     * Type of cell output.
+     */
+    output_type: 'error';
+
+    /**
+     * The name of the error.
+     */
+    ename: string;
+
+    /**
+     * The value, or message, of the error.
+     */
+    evalue: string;
+
+    /**
+     * The error's traceback.
+     */
+    traceback: string[];
+  }
+
+
+  /**
+   * An output union type.
+   */
+  export
+  type IOutput = IExecuteResult | IDisplayData | IStream | IError;
+}

--- a/test/src/nbformat.spec.ts
+++ b/test/src/nbformat.spec.ts
@@ -1,0 +1,44 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import expect = require('expect.js');
+
+import {
+  nbformat
+} from '../../lib/nbformat';
+
+
+const VALIDATE = nbformat.validateMimeValue;
+
+
+describe('notebook/nbformat', () => {
+
+  describe('validateMimeValue', () => {
+
+    it('should return true for a valid json object', () => {
+      expect(VALIDATE('application/json', { 'foo': 1 })).to.be(true);
+    });
+
+    it('should return true for a valid json-like object', () => {
+      expect(VALIDATE('application/foo+json', { 'foo': 1 })).to.be(true);
+    });
+
+    it('should return true for a valid string object', () => {
+      expect(VALIDATE('text/plain', 'foo')).to.be(true);
+    });
+
+    it('should return true for a valid array of strings object', () => {
+      expect(VALIDATE('text/plain', ['foo', 'bar'])).to.be(true);
+    });
+
+    it('should return false for a json type with string data', () => {
+      expect(VALIDATE('application/foo+json', 'bar')).to.be(false);
+    });
+
+    it('should return false for a string type with json data', () => {
+      expect(VALIDATE('foo/bar', { 'foo': 1 })).to.be(false);
+    });
+
+  });
+
+});


### PR DESCRIPTION
Also upgrade to nbformat 4.1.
Uses nbformat where applicable in the kernel message interfaces.
Allows users to access the interface without depending on JupyterLab (and soon @jupyterlab/notebook).