### PR TITLE
Do not validate the parent header

### DIFF
--- a/src/kernel/default.ts
+++ b/src/kernel/default.ts
@@ -672,7 +672,7 @@ class DefaultKernel implements Kernel.IKernel {
     try {
       validate.validateMessage(msg);
     } catch (error) {
-      console.error(error.message);
+      console.error(`Invalid message: ${error.message}`);
       return;
     }
     if (msg.parent_header) {

--- a/src/kernel/validate.ts
+++ b/src/kernel/validate.ts
@@ -82,9 +82,6 @@ function validateMessage(msg: KernelMessage.IMessage) : void {
   validateProperty(msg, 'content', 'object');
   validateProperty(msg, 'channel', 'string');
   validateHeader(msg.header);
-  if (Object.keys(msg.parent_header).length > 0) {
-    validateHeader(msg.parent_header as KernelMessage.IHeader);
-  }
   if (msg.channel === 'iopub') {
     validateIOPubContent(msg as KernelMessage.IIOPubMessage);
   }


### PR DESCRIPTION
The requirements for the parent header of a message are not as stringent.  These messages will now only be directly handled if they have the fields of interest, otherwise they will be ignored.

Also improves the error message for improper messages.

Fixes #258.