### PR TITLE
Switch back to a static set of specs

### DIFF
--- a/src/kernel/kernel.ts
+++ b/src/kernel/kernel.ts
@@ -554,11 +554,9 @@ namespace Kernel {
     ajaxSettings?: IAjaxSettings;
 
     /**
-     * Get the kernel specs.
-     *
-     * @returns A promise that resolves with the most recently fecthed specs.
+     * Get the most recently fetched kernel specs.
      */
-    specs(): Promise<ISpecModels>;
+    readonly specs: Kernel.ISpecModels | null;
 
     /**
      * Create an iterator over the known running kernels.
@@ -568,15 +566,11 @@ namespace Kernel {
     running(): IIterator<IModel>;
 
     /**
-     * Force an update of the available kernel specs.
+     * Fetch the specs from the server.
      *
      * @returns A promise that resolves with the kernel spec models.
-     *
-     * #### Notes
-     * This is only meant to be called by the user if the kernel specs
-     * are known to have changed on disk.
      */
-    updateSpecs(): Promise<ISpecModels>;
+    fetchSpecs(): Promise<ISpecModels>;
 
     /**
      * Force a refresh of the running kernels.

--- a/src/kernel/manager.ts
+++ b/src/kernel/manager.ts
@@ -103,18 +103,10 @@ class KernelManager implements Kernel.IManager {
   }
 
   /**
-   * Get the kernel specs.
-   *
-   * @returns A promise that resolves with the most recently fetched specs.
+   * Get the most recently fetched kernel specs.
    */
-  specs(): Promise<Kernel.ISpecModels> {
-    if (this._specs) {
-      return Promise.resolve(this._specs);
-    }
-    if (this._specPromise) {
-      return this._specPromise;
-    }
-    return this.updateSpecs();
+  get specs(): Kernel.ISpecModels | null {
+    return this._specs;
   }
 
   /**
@@ -127,27 +119,22 @@ class KernelManager implements Kernel.IManager {
   }
 
   /**
-   * Force an update of the available kernel specs.
+   * Fetch the specs from the server.
    *
    * @returns A promise that resolves with the kernel spec models.
-   *
-   * #### Notes
-   * This is only meant to be called by the user if the kernel specs
-   * are known to have changed on disk.
    */
-  updateSpecs(): Promise<Kernel.ISpecModels> {
+  fetchSpecs(): Promise<Kernel.ISpecModels> {
     let options = {
       baseUrl: this._baseUrl,
       ajaxSettings: this.ajaxSettings
     };
-    this._specPromise = Kernel.getSpecs(options).then(specs => {
+    return Kernel.getSpecs(options).then(specs => {
       if (!deepEqual(specs, this._specs)) {
         this._specs = specs;
         this.specsChanged.emit(specs);
       }
       return specs;
     });
-    return this._specPromise;
   }
 
   /**
@@ -262,7 +249,6 @@ class KernelManager implements Kernel.IManager {
   private _isDisposed = false;
   private _updateTimer = -1;
   private _refreshTimer = -1;
-  private _specPromise: Promise<Kernel.ISpecModels>;
 }
 
 

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -78,21 +78,6 @@ class SessionManager implements Session.IManager {
   }
 
   /**
-   * Get the kernel specs.
-   *
-   * @returns A promise that resolves with the most recently fetched specs.
-   */
-  specs(): Promise<Kernel.ISpecModels> {
-    if (this._specs) {
-      return Promise.resolve(this._specs);
-    }
-    if (this._specPromise) {
-      return this._specPromise;
-    }
-    return this.updateSpecs();
-  }
-
-  /**
    * The base url of the manager.
    */
   get baseUrl(): string {
@@ -121,6 +106,13 @@ class SessionManager implements Session.IManager {
   }
 
   /**
+   * Get the most recently fetched kernel specs.
+   */
+  get specs(): Kernel.ISpecModels | null {
+    return this._specs;
+  }
+
+  /**
    * Create an iterator over the most recent running sessions.
    *
    * @returns A new iterator over the running sessions.
@@ -130,27 +122,22 @@ class SessionManager implements Session.IManager {
   }
 
   /**
-   * Force an update of the available kernel specs.
+   * Fetch the specs from the server.
    *
    * @returns A promise that resolves with the kernel spec models.
-   *
-   * #### Notes
-   * This is only meant to be called by the user if the kernel specs
-   * are known to have changed on disk.
    */
-  updateSpecs(): Promise<Kernel.ISpecModels> {
+  fetchSpecs(): Promise<Kernel.ISpecModels> {
     let options = {
       baseUrl: this._baseUrl,
       ajaxSettings: this.ajaxSettings
     };
-    this._specPromise = Kernel.getSpecs(options).then(specs => {
+    return Kernel.getSpecs(options).then(specs => {
       if (!deepEqual(specs, this._specs)) {
         this._specs = specs;
         this.specsChanged.emit(specs);
       }
       return specs;
     });
-    return this._specPromise;
   }
 
   /**
@@ -260,7 +247,6 @@ class SessionManager implements Session.IManager {
   private _specs: Kernel.ISpecModels = null;
   private _updateTimer = -1;
   private _refreshTimer = -1;
-  private _specPromise: Promise<Kernel.ISpecModels>;
 }
 
 // Define the signals for the `SessionManager` class.

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -366,11 +366,9 @@ namespace Session {
     ajaxSettings?: IAjaxSettings;
 
     /**
-     * Get the kernel specs.
-     *
-     * @returns A promise that resolves with the most recently fecthed specs.
+     * Get the most recently fetched kernel specs.
      */
-    specs(): Promise<Kernel.ISpecModels>;
+    readonly specs: Kernel.ISpecModels | null;
 
     /**
      * Create an iterator over the known running sessions.
@@ -437,15 +435,11 @@ namespace Session {
     shutdown(id: string): Promise<void>;
 
     /**
-     * Force an update of the available kernel specs.
+     * Fetch the specs from the server.
      *
      * @returns A promise that resolves with the kernel spec models.
-     *
-     * #### Notes
-     * This is only meant to be called by the user if the kernel specs
-     * are known to have changed on disk.
      */
-    updateSpecs(): Promise<Kernel.ISpecModels>;
+    fetchSpecs(): Promise<Kernel.ISpecModels>;
 
     /**
      * Force a refresh of the running sessions.

--- a/test/src/kernel/manager.spec.ts
+++ b/test/src/kernel/manager.spec.ts
@@ -102,16 +102,18 @@ describe('kernel/manager', () => {
 
     });
 
-    describe('#specs()', () => {
+    describe('#specs', () => {
 
       it('should get the kernel specs', (done) => {
+        expect(manager.specs).to.be(null);
         let handler = new RequestHandler(() => {
           handler.respond(200, KERNELSPECS);
         });
-        manager.specs().then(specs => {
-          expect(specs.default).to.be(KERNELSPECS.default);
+        manager.specsChanged.connect(() => {
+          expect(manager.specs.default).to.be(KERNELSPECS.default);
           done();
-        }).catch(done);
+        });
+        manager.fetchSpecs();
       });
 
     });
@@ -148,7 +150,7 @@ describe('kernel/manager', () => {
         let handler = new RequestHandler(() => {
           handler.respond(200, KERNELSPECS);
         });
-        manager.updateSpecs();
+        manager.fetchSpecs();
       });
 
     });
@@ -173,7 +175,7 @@ describe('kernel/manager', () => {
 
     });
 
-    describe('#updateSpecs()', () => {
+    describe('#fetchSpecs()', () => {
 
       it('should get the list of kernel specs', (done) => {
         let ids = {
@@ -184,7 +186,7 @@ describe('kernel/manager', () => {
           tester.respond(200, { 'default': 'python',
                                'kernelspecs': ids });
         };
-        manager.updateSpecs().then(specs => {
+        manager.fetchSpecs().then(specs => {
           let names = Object.keys(specs.kernelspecs);
           expect(names[0]).to.be('python');
           expect(names[1]).to.be('python3');

--- a/test/src/session/manager.spec.ts
+++ b/test/src/session/manager.spec.ts
@@ -108,16 +108,18 @@ describe('session', () => {
 
     });
 
-    describe('#specs()', () => {
+    describe('#specs', () => {
 
       it('should get the kernel specs', (done) => {
+        expect(manager.specs).to.be(null);
         let handler = new RequestHandler(() => {
           handler.respond(200, KERNELSPECS);
         });
-        manager.specs().then(specs => {
-          expect(specs.default).to.be(KERNELSPECS.default);
+        manager.specsChanged.connect(() => {
+          expect(manager.specs.default).to.be(KERNELSPECS.default);
           done();
-        }).catch(done);
+        });
+        manager.fetchSpecs();
       });
 
     });
@@ -150,7 +152,7 @@ describe('session', () => {
         let handler = new RequestHandler(() => {
           handler.respond(200, KERNELSPECS);
         });
-        manager.updateSpecs();
+        manager.fetchSpecs();
       });
 
     });


### PR DESCRIPTION
I tried to use the API from #265, but ended up having to cache the specs in several places.