### PR TITLE
Handle object readiness and clean up manager auto-refresh

### DIFF
--- a/src/kernel/default.ts
+++ b/src/kernel/default.ts
@@ -88,7 +88,7 @@ class DefaultKernel implements Kernel.IKernel {
 
     this._readyPromise = Private.findSpecs(options).then(specs => {
       this._spec = specs.kernelspecs[this._name];
-      return this._connectionPromise;
+      return this._connectionPromise.promise;
     });
     this._createSocket();
     Private.runningKernels.pushBack(this);

--- a/src/kernel/kernel.ts
+++ b/src/kernel/kernel.ts
@@ -108,28 +108,25 @@ namespace Kernel {
     readonly status: Kernel.Status;
 
     /**
-     * Get the kernel info.
-     *
-     * @returns A promise that resolves with a cached kernel info.
+     * The cached kernel info.
      *
      * #### Notes
-     * This value is cached when a kernel connection is made.
-     * This can be used to wait for a kernel connection before taking
-     * further action on the kernel.  It can also be used to get the kernel
-     * info without generating an extra kernel message.
+     * This value will be null until the kernel is ready.
      */
-    info(): Promise<KernelMessage.IInfoReply>;
+    readonly info: KernelMessage.IInfoReply | null;
 
     /**
-     * Get the cached kernel spec.
-     *
-     * @returns A promise that resolves with a cached kernel spec.
+     * The cached kernel spec.
      *
      * #### Notes
-     * It will use the cached kernel spec models for this base url or
-     * fetch them from the server.
+     * This value will be null until the kernel is ready.
      */
-    spec(): Promise<Kernel.ISpecModel>;
+    readonly spec: Kernel.ISpecModel | null;
+
+    /**
+     * A promise that is fulfilled when the kernel is initially ready.
+     */
+    ready(): Promise<void>;
 
     /**
      * Send a shell message to the kernel.
@@ -555,8 +552,16 @@ namespace Kernel {
 
     /**
      * The kernel spec models.
+     *
+     * #### Notes
+     * The value will be null until the manager is ready.
      */
     readonly specs: Kernel.ISpecModels | null;
+
+    /**
+     * A promise that fulfills when the manager is initially ready.
+     */
+    ready(): Promise<void>;
 
     /**
      * Create an iterator over the known running kernels.

--- a/src/kernel/kernel.ts
+++ b/src/kernel/kernel.ts
@@ -529,7 +529,7 @@ namespace Kernel {
   export
   interface IManager extends IDisposable {
     /**
-     * A signal emitted when the specs change.
+     * A signal emitted when the kernel specs change.
      */
     specsChanged: ISignal<IManager, ISpecModels>;
 
@@ -554,7 +554,7 @@ namespace Kernel {
     ajaxSettings?: IAjaxSettings;
 
     /**
-     * Get the most recently fetched kernel specs.
+     * The kernel spec models.
      */
     readonly specs: Kernel.ISpecModels | null;
 
@@ -566,22 +566,26 @@ namespace Kernel {
     running(): IIterator<IModel>;
 
     /**
-     * Fetch the specs from the server.
+     * Force a refresh of the specs from the server.
      *
-     * @returns A promise that resolves with the kernel spec models.
+     * @returns A promise that resolves when the specs are fetched.
+     *
+     * #### Notes
+     * This is intended to be called only in response to a user action,
+     * since the manager maintains its internal state.
      */
-    fetchSpecs(): Promise<ISpecModels>;
+    refreshSpecs(): Promise<void>;
 
     /**
      * Force a refresh of the running kernels.
      *
-     * @returns A promise that with the list of running kernels.
+     * @returns A promise that resolves when the models are refreshed.
      *
      * #### Notes
-     * This is not typically meant to be called by the user, since the
-     * manager maintains its own internal state.
+     * This is intended to be called only in response to a user action,
+     * since the manager maintains its internal state.
      */
-    refreshRunning(): Promise<IModel[]>;
+    refreshRunning(): Promise<void>;
 
     /**
      * Start a new kernel.

--- a/src/kernel/manager.ts
+++ b/src/kernel/manager.ts
@@ -79,8 +79,8 @@ class KernelManager implements Kernel.IManager {
       return;
     }
     this._isDisposed = true;
-    clearTimeout(this._runningTimer);
-    clearTimeout(this._specsTimer);
+    clearInterval(this._runningTimer);
+    clearInterval(this._specsTimer);
     clearSignalData(this);
     this._specs = null;
     this._running = [];

--- a/src/kernel/manager.ts
+++ b/src/kernel/manager.ts
@@ -228,7 +228,6 @@ class KernelManager implements Kernel.IManager {
         this._running = running.slice();
         this.runningChanged.emit(running);
       }
-      return running;
     });
   }
 

--- a/src/kernel/manager.ts
+++ b/src/kernel/manager.ts
@@ -39,7 +39,19 @@ class KernelManager implements Kernel.IManager {
     this._baseUrl = options.baseUrl || utils.getBaseUrl();
     this._wsUrl = options.wsUrl || utils.getWsUrl(this._baseUrl);
     this._ajaxSettings = JSON.stringify(options.ajaxSettings || {});
-    this._scheduleUpdate();
+
+    // Initialize internal data.
+    this._refreshSpecs().then(() => {
+      this._refreshRunning();
+    });
+
+    // Set up polling.
+    this._runningTimer = setInterval(() => {
+      this._refreshRunning();
+    }, 10000);
+    this._specsTimer = setInterval(() => {
+      this._refreshSpecs();
+    }, 61000);
   }
 
   /**
@@ -67,8 +79,8 @@ class KernelManager implements Kernel.IManager {
       return;
     }
     this._isDisposed = true;
-    clearTimeout(this._updateTimer);
-    clearTimeout(this._refreshTimer);
+    clearTimeout(this._runningTimer);
+    clearTimeout(this._specsTimer);
     clearSignalData(this);
     this._specs = null;
     this._running = [];
@@ -119,77 +131,38 @@ class KernelManager implements Kernel.IManager {
   }
 
   /**
-   * Fetch the specs from the server.
+   * Force a refresh of the specs from the server.
    *
-   * @returns A promise that resolves with the kernel spec models.
+   * @returns A promise that resolves when the specs are fetched.
+   *
+   * #### Notes
+   * This is intended to be called only in response to a user action,
+   * since the manager maintains its internal state.
    */
-  fetchSpecs(): Promise<Kernel.ISpecModels> {
-    if (this._specPromise) {
-      return this._specPromise;
-    }
-    let options = {
-      baseUrl: this._baseUrl,
-      ajaxSettings: this.ajaxSettings
-    };
-    this._specPromise = Kernel.getSpecs(options).then(specs => {
-      this._specPromise = null;
-      if (!deepEqual(specs, this._specs)) {
-        this._specs = specs;
-        this.specsChanged.emit(specs);
-      }
-      return specs;
-    });
-    return this._specPromise;
+  refreshSpecs(): Promise<void> {
+    return this._refreshSpecs();
   }
 
   /**
    * Force a refresh of the running kernels.
    *
-   * @returns A promise that with the list of running kernels.
+   * @returns A promise that with the list of running sessions.
    *
    * #### Notes
    * This is not typically meant to be called by the user, since the
    * manager maintains its own internal state.
    */
-  refreshRunning(): Promise<Kernel.IModel[]> {
-    clearTimeout(this._updateTimer);
-    clearTimeout(this._refreshTimer);
-
-    if (this._runningPromise) {
-      return this._runningPromise;
-    }
-    let promise = Kernel.listRunning(this._getOptions()).then(running => {
-      this._runningPromise = null;
-      if (!deepEqual(running, this._running)) {
-        this._running = running.slice();
-        this.runningChanged.emit(running);
-      }
-      this._refreshTimer = setTimeout(() => {
-        this.refreshRunning();
-      }, 10000);
-      return running;
-    });
-    this._runningPromise = promise;
-    return promise;
+  refreshRunning(): Promise<void> {
+    return this._refreshRunning();
   }
 
   /**
    * Start a new kernel.  See also [[startNewKernel]].
    *
    * @param options - Overrides for the default options.
-   *
-   * #### Notes
-   * This will emit [[runningChanged]] if the running kernels list
-   * changes.
    */
   startNew(options?: Kernel.IOptions): Promise<Kernel.IKernel> {
-    return Kernel.startNew(this._getOptions(options)).then(kernel => {
-      this._scheduleUpdate();
-      kernel.terminated.connect(() => {
-          this._scheduleUpdate();
-      });
-      return kernel;
-    });
+    return Kernel.startNew(this._getOptions(options));
   }
 
   /**
@@ -207,12 +180,7 @@ class KernelManager implements Kernel.IManager {
    * @param options - Overrides for the default options.
    */
   connectTo(id: string, options?: Kernel.IOptions): Promise<Kernel.IKernel> {
-    return Kernel.connectTo(id, this._getOptions(options)).then(kernel => {
-      kernel.terminated.connect(() => {
-          this._scheduleUpdate();
-      });
-      return kernel;
-    });
+    return Kernel.connectTo(id, this._getOptions(options));
   }
 
   /**
@@ -225,8 +193,35 @@ class KernelManager implements Kernel.IManager {
    * changes.
    */
   shutdown(id: string, options?: Kernel.IOptions): Promise<void> {
-    return Kernel.shutdown(id, this._getOptions(options)).then(() => {
-      this._scheduleUpdate();
+    return Kernel.shutdown(id, this._getOptions(options));
+  }
+
+  /**
+   * Refresh the specs.
+   */
+  private _refreshSpecs(): Promise<void> {
+    let options = {
+      baseUrl: this._baseUrl,
+      ajaxSettings: this.ajaxSettings
+    };
+    return Kernel.getSpecs(options).then(specs => {
+      if (!deepEqual(specs, this._specs)) {
+        this._specs = specs;
+        this.specsChanged.emit(specs);
+      }
+    });
+  }
+
+  /**
+   * Refresh the running sessions.
+   */
+  private _refreshRunning(): Promise<void> {
+    return Kernel.listRunning(this._getOptions({})).then(running => {
+      if (!deepEqual(running, this._running)) {
+        this._running = running.slice();
+        this.runningChanged.emit(running);
+      }
+      return running;
     });
   }
 
@@ -240,28 +235,14 @@ class KernelManager implements Kernel.IManager {
     return options;
   }
 
-  /**
-   * Schedule an update of the running kernels.
-   */
-  private _scheduleUpdate(): void {
-    if (this._updateTimer !== -1) {
-      return;
-    }
-    this._updateTimer = setTimeout(() => {
-      this.refreshRunning();
-    }, 100);
-  }
-
   private _baseUrl = '';
   private _wsUrl = '';
   private _ajaxSettings = '';
   private _running: Kernel.IModel[] = [];
   private _specs: Kernel.ISpecModels = null;
   private _isDisposed = false;
-  private _updateTimer = -1;
-  private _refreshTimer = -1;
-  private _specPromise: Promise<Kernel.ISpecModels> = null;
-  private _runningPromise: Promise<Kernel.IModel> = null;
+  private _runningTimer = -1;
+  private _specsTimer = -1;
 }
 
 

--- a/src/kernel/manager.ts
+++ b/src/kernel/manager.ts
@@ -132,9 +132,9 @@ class KernelManager implements Kernel.IManager {
       ajaxSettings: this.ajaxSettings
     };
     this._specPromise = Kernel.getSpecs(options).then(specs => {
+      this._specPromise = null;
       if (!deepEqual(specs, this._specs)) {
         this._specs = specs;
-        this._specPromise = null;
         this.specsChanged.emit(specs);
       }
       return specs;
@@ -159,9 +159,9 @@ class KernelManager implements Kernel.IManager {
       return this._runningPromise;
     }
     let promise = Kernel.listRunning(this._getOptions()).then(running => {
+      this._runningPromise = null;
       if (!deepEqual(running, this._running)) {
         this._running = running.slice();
-        this._runningPromise = null;
         this.runningChanged.emit(running);
       }
       this._refreshTimer = setTimeout(() => {

--- a/src/kernel/manager.ts
+++ b/src/kernel/manager.ts
@@ -41,8 +41,8 @@ class KernelManager implements Kernel.IManager {
     this._ajaxSettings = JSON.stringify(options.ajaxSettings || {});
 
     // Initialize internal data.
-    this._refreshSpecs().then(() => {
-      this._refreshRunning();
+    this._readyPromise = this._refreshSpecs().then(() => {
+      return this._refreshRunning();
     });
 
     // Set up polling.
@@ -119,6 +119,13 @@ class KernelManager implements Kernel.IManager {
    */
   get specs(): Kernel.ISpecModels | null {
     return this._specs;
+  }
+
+  /**
+   * A promise that fulfills when the manager is ready.
+   */
+  ready(): Promise<void> {
+    return this._readyPromise;
   }
 
   /**
@@ -243,6 +250,7 @@ class KernelManager implements Kernel.IManager {
   private _isDisposed = false;
   private _runningTimer = -1;
   private _specsTimer = -1;
+  private _readyPromise: Promise<void>;
 }
 
 

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -53,6 +53,9 @@ class ServiceManager implements ServiceManager.IManager {
     this._sessionManager.specsChanged.connect((sender, specs) => {
       this.specsChanged.emit(specs);
     });
+    this._readyPromise = this._sessionManager.ready().then(() => {
+      return this._terminalManager.ready;
+    });
   }
 
   /**
@@ -116,10 +119,18 @@ class ServiceManager implements ServiceManager.IManager {
     return this._terminalManager;
   }
 
+  /**
+   * A promise that fulfills when the manager is ready.
+   */
+  ready(): Promise<void> {
+    return this._readyPromise;
+  }
+
   private _sessionManager: SessionManager = null;
   private _contentsManager: ContentsManager = null;
   private _terminalManager: TerminalManager = null;
   private _isDisposed = false;
+  private _readyPromise: Promise<void>;
 }
 
 
@@ -162,6 +173,11 @@ namespace ServiceManager {
      * The terminals manager for the manager.
      */
     readonly terminals: TerminalSession.IManager;
+
+    /**
+     * A promise that fulfills when the manager is initially ready.
+     */
+    ready(): Promise<void>;
   }
 
   /**

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -45,8 +45,8 @@ class SessionManager implements Session.IManager {
     this._ajaxSettings = JSON.stringify(options.ajaxSettings || {});
 
     // Initialize internal data.
-    this._refreshSpecs().then(() => {
-      this._refreshRunning();
+    this._readyPromise = this._refreshSpecs().then(() => {
+      return this._refreshRunning();
     });
 
     // Set up polling.
@@ -122,6 +122,13 @@ class SessionManager implements Session.IManager {
    */
   get specs(): Kernel.ISpecModels | null {
     return this._specs;
+  }
+
+  /**
+   * A promise that fulfills when the manager is ready.
+   */
+  ready(): Promise<void> {
+    return this._readyPromise;
   }
 
   /**
@@ -244,6 +251,7 @@ class SessionManager implements Session.IManager {
   private _specs: Kernel.ISpecModels = null;
   private _runningTimer = -1;
   private _specsTimer = -1;
+  private _readyPromise: Promise<void>;
 }
 
 // Define the signals for the `SessionManager` class.

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -239,7 +239,6 @@ class SessionManager implements Session.IManager {
         this._running = running.slice();
         this.runningChanged.emit(running);
       }
-      return running;
     });
   }
 

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -135,9 +135,9 @@ class SessionManager implements Session.IManager {
       ajaxSettings: this.ajaxSettings
     };
     this._specPromise = Kernel.getSpecs(options).then(specs => {
+      this._specPromise = null;
       if (!deepEqual(specs, this._specs)) {
         this._specs = specs;
-        this._specPromise = null;
         this.specsChanged.emit(specs);
       }
       return specs;
@@ -163,9 +163,9 @@ class SessionManager implements Session.IManager {
       return this._runningPromise;
     }
     let promise = Session.listRunning(this._getOptions({})).then(running => {
+      this._runningPromise = null;
       if (!deepEqual(running, this._running)) {
         this._running = running.slice();
-        this._runningPromise = null;
         this.runningChanged.emit(running);
       }
       // Throttle the next request.

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -83,8 +83,8 @@ class SessionManager implements Session.IManager {
       return;
     }
     this._isDisposed = true;
-    clearTimeout(this._runningTimer);
-    clearTimeout(this._specsTimer);
+    clearInterval(this._runningTimer);
+    clearInterval(this._specsTimer);
     clearSignalData(this);
     this._running = [];
   }

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -43,7 +43,19 @@ class SessionManager implements Session.IManager {
     this._baseUrl = options.baseUrl || utils.getBaseUrl();
     this._wsUrl = options.wsUrl || utils.getWsUrl(this._baseUrl);
     this._ajaxSettings = JSON.stringify(options.ajaxSettings || {});
-    this._scheduleUpdate();
+
+    // Initialize internal data.
+    this._refreshSpecs().then(() => {
+      this._refreshRunning();
+    });
+
+    // Set up polling.
+    this._runningTimer = setInterval(() => {
+      this._refreshRunning();
+    }, 10000);
+    this._specsTimer = setInterval(() => {
+      this._refreshSpecs();
+    }, 61000);
   }
 
   /**
@@ -71,8 +83,8 @@ class SessionManager implements Session.IManager {
       return;
     }
     this._isDisposed = true;
-    clearTimeout(this._updateTimer);
-    clearTimeout(this._refreshTimer);
+    clearTimeout(this._runningTimer);
+    clearTimeout(this._specsTimer);
     clearSignalData(this);
     this._running = [];
   }
@@ -122,27 +134,16 @@ class SessionManager implements Session.IManager {
   }
 
   /**
-   * Fetch the specs from the server.
+   * Force a refresh of the specs from the server.
    *
-   * @returns A promise that resolves with the kernel spec models.
+   * @returns A promise that resolves when the specs are fetched.
+   *
+   * #### Notes
+   * This is intended to be called only in response to a user action,
+   * since the manager maintains its internal state.
    */
-  fetchSpecs(): Promise<Kernel.ISpecModels> {
-    if (this._specPromise) {
-      return this._specPromise;
-    }
-    let options = {
-      baseUrl: this._baseUrl,
-      ajaxSettings: this.ajaxSettings
-    };
-    this._specPromise = Kernel.getSpecs(options).then(specs => {
-      this._specPromise = null;
-      if (!deepEqual(specs, this._specs)) {
-        this._specs = specs;
-        this.specsChanged.emit(specs);
-      }
-      return specs;
-    });
-    return this._specPromise;
+  refreshSpecs(): Promise<void> {
+    return this._refreshSpecs();
   }
 
   /**
@@ -154,31 +155,8 @@ class SessionManager implements Session.IManager {
    * This is not typically meant to be called by the user, since the
    * manager maintains its own internal state.
    */
-  refreshRunning(): Promise<Session.IModel[]> {
-
-    clearTimeout(this._updateTimer);
-    clearTimeout(this._refreshTimer);
-
-    if (this._runningPromise) {
-      return this._runningPromise;
-    }
-    let promise = Session.listRunning(this._getOptions({})).then(running => {
-      this._runningPromise = null;
-      if (!deepEqual(running, this._running)) {
-        this._running = running.slice();
-        this.runningChanged.emit(running);
-      }
-      // Throttle the next request.
-      if (this._updateTimer !== -1) {
-        this._scheduleUpdate();
-      }
-      this._refreshTimer = setTimeout(() => {
-        this.refreshRunning();
-      }, 10000);
-      return running;
-    });
-    this._runningPromise = promise;
-    return promise;
+  refreshRunning(): Promise<void> {
+    return this._refreshRunning();
   }
 
   /**
@@ -188,11 +166,7 @@ class SessionManager implements Session.IManager {
    *   `'path'`.
    */
   startNew(options: Session.IOptions): Promise<Session.ISession> {
-    return Session.startNew(this._getOptions(options)).then(session => {
-      this._scheduleUpdate();
-      session.terminated.connect(() => { this._scheduleUpdate(); });
-      return session;
-    });
+    return Session.startNew(this._getOptions(options));
   }
 
   /**
@@ -213,19 +187,14 @@ class SessionManager implements Session.IManager {
    * Connect to a running session.  See also [[connectToSession]].
    */
   connectTo(id: string, options?: Session.IOptions): Promise<Session.ISession> {
-    return Session.connectTo(id, this._getOptions(options)).then(session => {
-      session.terminated.connect(() => { this._scheduleUpdate(); });
-      return session;
-    });
+    return Session.connectTo(id, this._getOptions(options));
   }
 
   /**
    * Shut down a session by id.
    */
   shutdown(id: string, options?: Session.IOptions): Promise<void> {
-    return Session.shutdown(id, this._getOptions(options)).then(() => {
-      this._scheduleUpdate();
-    });
+    return Session.shutdown(id, this._getOptions(options));
   }
 
   /**
@@ -239,15 +208,32 @@ class SessionManager implements Session.IManager {
   }
 
   /**
-   * Schedule an update of the running sessions.
+   * Refresh the specs.
    */
-  private _scheduleUpdate(): void {
-    if (this._updateTimer !== -1) {
-      return;
-    }
-    this._updateTimer = setTimeout(() => {
-      this.refreshRunning();
-    }, 100);
+  private _refreshSpecs(): Promise<void> {
+    let options = {
+      baseUrl: this._baseUrl,
+      ajaxSettings: this.ajaxSettings
+    };
+    return Kernel.getSpecs(options).then(specs => {
+      if (!deepEqual(specs, this._specs)) {
+        this._specs = specs;
+        this.specsChanged.emit(specs);
+      }
+    });
+  }
+
+  /**
+   * Refresh the running sessions.
+   */
+  private _refreshRunning(): Promise<void> {
+    return Session.listRunning(this._getOptions({})).then(running => {
+      if (!deepEqual(running, this._running)) {
+        this._running = running.slice();
+        this.runningChanged.emit(running);
+      }
+      return running;
+    });
   }
 
   private _baseUrl = '';
@@ -256,10 +242,8 @@ class SessionManager implements Session.IManager {
   private _isDisposed = false;
   private _running: Session.IModel[] = [];
   private _specs: Kernel.ISpecModels = null;
-  private _updateTimer = -1;
-  private _refreshTimer = -1;
-  private _specPromise: Promise<Kernel.ISpecModels> = null;
-  private _runningPromise: Promise<Session.IModel[]> = null;
+  private _runningTimer = -1;
+  private _specsTimer = -1;
 }
 
 // Define the signals for the `SessionManager` class.

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -366,7 +366,7 @@ namespace Session {
     ajaxSettings?: IAjaxSettings;
 
     /**
-     * Get the most recently fetched kernel specs.
+     * The kernel spec models.
      */
     readonly specs: Kernel.ISpecModels | null;
 
@@ -435,22 +435,26 @@ namespace Session {
     shutdown(id: string): Promise<void>;
 
     /**
-     * Fetch the specs from the server.
+     * Force a refresh of the specs from the server.
      *
-     * @returns A promise that resolves with the kernel spec models.
+     * @returns A promise that resolves when the specs are fetched.
+     *
+     * #### Notes
+     * This is intended to be called only in response to a user action,
+     * since the manager maintains its internal state.
      */
-    fetchSpecs(): Promise<Kernel.ISpecModels>;
+    refreshSpecs(): Promise<void>;
 
     /**
      * Force a refresh of the running sessions.
      *
-     * @returns A promise that with the list of running sessions.
+     * @returns A promise that resolves when the models are refreshed.
      *
      * #### Notes
-     * This is not typically meant to be called by the user, since the
-     * manager maintains its own internal state.
+     * This is intended to be called only in response to a user action,
+     * since the manager maintains its internal state.
      */
-    refreshRunning(): Promise<IModel[]>;
+    refreshRunning(): Promise<void>;
   }
 
   /**

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -366,9 +366,17 @@ namespace Session {
     ajaxSettings?: IAjaxSettings;
 
     /**
-     * The kernel spec models.
+     * The cached kernel specs.
+     *
+     * #### Notes
+     * This value will be null until the manager is ready.
      */
     readonly specs: Kernel.ISpecModels | null;
+
+    /**
+     * A promise that is fulfilled when the manager is ready.
+     */
+    ready(): Promise<void>;
 
     /**
      * Create an iterator over the known running sessions.

--- a/src/terminal/manager.ts
+++ b/src/terminal/manager.ts
@@ -39,7 +39,7 @@ class TerminalManager implements TerminalSession.IManager {
     this._ajaxSettings = JSON.stringify(options.ajaxSettings || {});
 
     // Initialize internal data.
-    this._refreshRunning();
+    this._readyPromise = this._refreshRunning();
 
     // Set up polling.
     this._refreshTimer = setInterval(() => {
@@ -87,6 +87,7 @@ class TerminalManager implements TerminalSession.IManager {
     this._ajaxSettings = JSON.stringify(value);
   }
 
+
   /**
    * Dispose of the resources used by the manager.
    */
@@ -98,6 +99,13 @@ class TerminalManager implements TerminalSession.IManager {
     clearTimeout(this._refreshTimer);
     clearSignalData(this);
     this._running = [];
+  }
+
+  /**
+   * A promise that fulfills when the manager is ready.
+   */
+  ready(): Promise<void> {
+    return this._readyPromise;
   }
 
   /**
@@ -194,6 +202,7 @@ class TerminalManager implements TerminalSession.IManager {
   private _running: TerminalSession.IModel[] = [];
   private _isDisposed = false;
   private _refreshTimer = -1;
+  private _readyPromise: Promise<void>;
 }
 
 

--- a/src/terminal/manager.ts
+++ b/src/terminal/manager.ts
@@ -182,7 +182,6 @@ class TerminalManager implements TerminalSession.IManager {
         this._running = running.slice();
         this.runningChanged.emit(running);
       }
-      return running;
     });
   }
 

--- a/src/terminal/manager.ts
+++ b/src/terminal/manager.ts
@@ -96,7 +96,7 @@ class TerminalManager implements TerminalSession.IManager {
       return;
     }
     this._isDisposed = true;
-    clearTimeout(this._refreshTimer);
+    clearInterval(this._refreshTimer);
     clearSignalData(this);
     this._running = [];
   }

--- a/src/terminal/terminal.ts
+++ b/src/terminal/terminal.ts
@@ -277,12 +277,12 @@ namespace TerminalSession {
     /**
      * Force a refresh of the running terminal sessions.
      *
-     * @returns A promise that resolves with the list of running sessions.
+     * @returns A promise that with the list of running sessions.
      *
      * #### Notes
      * This is not typically meant to be called by the user, since the
      * manager maintains its own internal state.
      */
-    refreshRunning(): Promise<IModel[]>;
+    refreshRunning(): Promise<void>;
   }
 }

--- a/src/terminal/terminal.ts
+++ b/src/terminal/terminal.ts
@@ -70,6 +70,11 @@ namespace TerminalSession {
     ajaxSettings: utils.IAjaxSettings;
 
     /**
+     * A promise that fulfills when the session is initially ready.
+     */
+    ready(): Promise<void>;
+
+    /**
      * Send a message to the terminal session.
      */
     send(message: IMessage): void;
@@ -226,6 +231,11 @@ namespace TerminalSession {
      * The default ajax settings for the manager.
      */
     ajaxSettings?: IAjaxSettings;
+
+    /**
+     * A promise that fulfills when the manager is ready.
+     */
+    ready(): Promise<void>;
 
     /**
      * Create an iterator over the known running terminals.

--- a/test/src/integration.ts
+++ b/test/src/integration.ts
@@ -4,6 +4,10 @@
 import expect = require('expect.js');
 
 import {
+  toArray
+} from 'phosphor/lib/algorithm/iteration';
+
+import {
   JSONObject, deepEqual
 } from 'phosphor/lib/algorithm/json';
 
@@ -349,13 +353,14 @@ describe('jupyter.services - Integration', () => {
       let manager = new TerminalManager();
       manager.startNew().then(session => {
         return manager.refreshRunning();
-      }).then(running => {
+      }).then(() => {
+        let running = toArray(manager.running());
         expect(running.length).to.be(1);
         return manager.shutdown(running[0].name);
       }).then(() => {
         return manager.refreshRunning();
-      }).then(running => {
-        expect(running.length).to.be(0);
+      }).then(() => {
+        expect(manager.running().next).to.be(void 0);
         done();
       }).catch(done);
     });

--- a/test/src/integration.ts
+++ b/test/src/integration.ts
@@ -64,9 +64,7 @@ describe('jupyter.services - Integration', () => {
         return kernel.requestKernelInfo();
       }).then((info) => {
         content = info.content;
-        return kernel.info();
-      }).then(info => {
-        expect(deepEqual(content, info)).to.be(true);
+        expect(deepEqual(content, kernel.info)).to.be(true);
         return kernel.shutdown();
       }).then(done, done);
     });

--- a/test/src/integration.ts
+++ b/test/src/integration.ts
@@ -48,6 +48,8 @@ describe('jupyter.services - Integration', () => {
       let kernel: Kernel.IKernel;
       Kernel.startNew().then(value => {
         kernel = value;
+        return kernel.ready();
+      }).then(() => {
         return kernel.interrupt();
       }).then(() => {
         return kernel.restart();
@@ -349,7 +351,9 @@ describe('jupyter.services - Integration', () => {
 
     it('should create, list, and shutdown by name', (done) => {
       let manager = new TerminalManager();
-      manager.startNew().then(session => {
+      manager.ready().then(() => {
+        return manager.startNew();
+      }).then(session => {
         return manager.refreshRunning();
       }).then(() => {
         let running = toArray(manager.running());
@@ -358,7 +362,7 @@ describe('jupyter.services - Integration', () => {
       }).then(() => {
         return manager.refreshRunning();
       }).then(() => {
-        expect(manager.running().next).to.be(void 0);
+        expect(manager.running().next()).to.be(void 0);
         done();
       }).catch(done);
     });

--- a/test/src/kernel/comm.spec.ts
+++ b/test/src/kernel/comm.spec.ts
@@ -24,6 +24,8 @@ describe('jupyter.services - Comm', () => {
     tester = new KernelTester();
     Kernel.startNew().then(k => {
       kernel = k;
+      return kernel.ready();
+    }).then(() => {
       done();
     }).catch(done);
   });

--- a/test/src/kernel/kernel.spec.ts
+++ b/test/src/kernel/kernel.spec.ts
@@ -303,9 +303,6 @@ describe('kernel', () => {
 
     beforeEach((done) => {
       Kernel.startNew().then(k => {
-        tester.onRequest = () => {
-          tester.respond(200, KERNELSPECS);
-        };
         kernel = k;
         return kernel.ready();
       }).then(() => {

--- a/test/src/kernel/kernel.spec.ts
+++ b/test/src/kernel/kernel.spec.ts
@@ -303,6 +303,9 @@ describe('kernel', () => {
 
     beforeEach((done) => {
       Kernel.startNew().then(k => {
+        tester.onRequest = () => {
+          tester.respond(200, KERNELSPECS);
+        };
         kernel = k;
         return kernel.ready();
       }).then(() => {
@@ -549,6 +552,14 @@ describe('kernel', () => {
         return kernel.ready().then(() => {
           expect(kernel.spec.language).to.be('python');
         }).then(done, done);
+      });
+
+    });
+
+    context('#ready()', () => {
+
+      it('should resolve when the kernel is ready', (done) => {
+        return kernel.ready().then(done, done);
       });
 
     });

--- a/test/src/kernel/kernel.spec.ts
+++ b/test/src/kernel/kernel.spec.ts
@@ -304,7 +304,7 @@ describe('kernel', () => {
     beforeEach((done) => {
       Kernel.startNew().then(k => {
         kernel = k;
-        return kernel.info();
+        return kernel.ready();
       }).then(() => {
         done();
       }).catch(done);
@@ -532,8 +532,8 @@ describe('kernel', () => {
     context('#info', () => {
 
       it('should get the kernel info', (done) => {
-        return kernel.info().then(info => {
-          let name = info.language_info.name;
+        return kernel.ready().then(() => {
+          let name = kernel.info.language_info.name;
           expect(name).to.be(EXAMPLE_KERNEL_INFO.language_info.name);
         }).then(done, done);
       });
@@ -546,8 +546,8 @@ describe('kernel', () => {
         tester.onRequest = () => {
           tester.respond(200, KERNELSPECS);
         };
-        return kernel.spec().then(spec => {
-          expect(spec.language).to.be('python');
+        return kernel.ready().then(() => {
+          expect(kernel.spec.language).to.be('python');
         }).then(done, done);
       });
 
@@ -783,7 +783,7 @@ describe('kernel', () => {
     describe('#reconnect()', () => {
 
       it('should reconnect the websocket', (done) => {
-        kernel.info().then(() => {
+        kernel.ready().then(() => {
           return kernel.reconnect();
         }).then(() => {
           done();
@@ -792,7 +792,7 @@ describe('kernel', () => {
 
       it("should emit a `'reconnecting'` status", (done) => {
         let called = false;
-        kernel.info().then(() => {
+        kernel.ready().then(() => {
           return kernel.reconnect();
         }).then(() => {
           expect(called).to.be(true);

--- a/test/src/kernel/manager.spec.ts
+++ b/test/src/kernel/manager.spec.ts
@@ -113,7 +113,6 @@ describe('kernel/manager', () => {
           expect(manager.specs.default).to.be(KERNELSPECS.default);
           done();
         });
-        manager.fetchSpecs();
       });
 
     });
@@ -150,7 +149,6 @@ describe('kernel/manager', () => {
         let handler = new RequestHandler(() => {
           handler.respond(200, KERNELSPECS);
         });
-        manager.fetchSpecs();
       });
 
     });
@@ -175,9 +173,9 @@ describe('kernel/manager', () => {
 
     });
 
-    describe('#fetchSpecs()', () => {
+    describe('#refreshSpecs()', () => {
 
-      it('should get the list of kernel specs', (done) => {
+      it('should update list of kernel specs', (done) => {
         let ids = {
           'python': PYTHON_SPEC,
           'python3': PYTHON3_SPEC
@@ -186,8 +184,8 @@ describe('kernel/manager', () => {
           tester.respond(200, { 'default': 'python',
                                'kernelspecs': ids });
         };
-        manager.fetchSpecs().then(specs => {
-          let names = Object.keys(specs.kernelspecs);
+        manager.refreshSpecs().then(() => {
+          let names = Object.keys(manager.specs.kernelspecs);
           expect(names[0]).to.be('python');
           expect(names[1]).to.be('python3');
           done();
@@ -198,7 +196,7 @@ describe('kernel/manager', () => {
 
     describe('#refreshRunning()', () => {
 
-      it('should list the running kernels', (done) => {
+      it('should update the running kernels', (done) => {
         let data = [
           { id: uuid(), name: 'test' },
           { id: uuid(), name: 'test2' }
@@ -206,8 +204,8 @@ describe('kernel/manager', () => {
         tester.onRequest = () => {
           tester.respond(200, data);
         };
-        manager.refreshRunning().then(response => {
-          let running = toArray(response);
+        manager.refreshRunning().then(() => {
+          let running = toArray(manager.running());
           expect(running[0]).to.eql(data[0]);
           expect(running[1]).to.eql(data[1]);
           done();

--- a/test/src/kernel/manager.spec.ts
+++ b/test/src/kernel/manager.spec.ts
@@ -12,7 +12,7 @@ import {
 } from 'phosphor/lib/algorithm/json';
 
 import {
-  uuid
+  uuid, copy
 } from '../../../lib/utils';
 
 import {
@@ -20,7 +20,7 @@ import {
 } from '../../../lib/kernel';
 
 import {
-  RequestHandler, KernelTester, KERNEL_OPTIONS, PYTHON_SPEC, KERNELSPECS
+  KernelTester, KERNEL_OPTIONS, PYTHON_SPEC, KERNELSPECS
 } from '../utils';
 
 
@@ -34,10 +34,22 @@ describe('kernel/manager', () => {
 
   let tester: KernelTester;
   let manager: KernelManager;
+  let data: Kernel.IModel[];
 
-  beforeEach(() => {
+  beforeEach((done) => {
     tester = new KernelTester();
+    data = [{ id: uuid(), name: 'test' },
+            { id: uuid(), name: 'test2' }];
+    tester.onRequest = () => {
+      tester.respond(200, KERNELSPECS);
+      tester.onRequest = () => {
+        tester.respond(200, data);
+      };
+    };
     manager = new KernelManager();
+    expect(manager.specs).to.be(null);
+    expect(manager.running().next()).to.be(void 0);
+    manager.ready().then(done, done);
   });
 
   afterEach(() => {
@@ -50,23 +62,9 @@ describe('kernel/manager', () => {
     describe('#constructor()', () => {
 
       it('should take the options as an argument', () => {
+        manager.dispose();
         manager = new KernelManager(KERNEL_OPTIONS);
         expect(manager instanceof KernelManager).to.be(true);
-      });
-
-      it('should trigger an update of running sessions', (done) => {
-        let data: Kernel.IModel[] = [
-          { id: uuid(), name: 'test' },
-          { id: uuid(), name: 'test2' }
-        ];
-        manager.runningChanged.connect((sender, args) => {
-          expect(sender).to.be(manager);
-          expect(deepEqual(toArray(args), data)).to.be(true);
-          done();
-        });
-        tester.onRequest = () => {
-          tester.respond(200, data);
-        };
       });
 
     });
@@ -104,35 +102,17 @@ describe('kernel/manager', () => {
 
     describe('#specs', () => {
 
-      it('should get the kernel specs', (done) => {
-        expect(manager.specs).to.be(null);
-        let handler = new RequestHandler(() => {
-          handler.respond(200, KERNELSPECS);
-        });
-        manager.specsChanged.connect(() => {
-          expect(manager.specs.default).to.be(KERNELSPECS.default);
-          done();
-        });
+      it('should get the kernel specs', () => {
+        expect(manager.specs.default).to.be(KERNELSPECS.default);
       });
 
     });
 
     describe('#running()', () => {
 
-      it('should get the running sessions', (done) => {
-        let data: Kernel.IModel[] = [
-          { id: uuid(), name: 'test' },
-          { id: uuid(), name: 'test2' }
-        ];
-        manager.runningChanged.connect((sender, args) => {
-          let test = deepEqual(toArray(args), toArray(manager.running()));
-          expect(test).to.be(true);
-          done();
-        });
-        tester.onRequest = () => {
-          tester.respond(200, data);
-        };
-        manager.refreshRunning();
+      it('should get the running sessions', () => {
+        let test = deepEqual(toArray(data), toArray(manager.running()));
+        expect(test).to.be(true);
       });
 
     });
@@ -140,15 +120,18 @@ describe('kernel/manager', () => {
     describe('#specsChanged', () => {
 
       it('should be emitted when the specs change', (done) => {
+        let specs = copy(KERNELSPECS) as Kernel.ISpecModels;
+        specs.default = 'shell';
         manager.specsChanged.connect((sender, args) => {
           expect(sender).to.be(manager);
-          expect(deepEqual(args, KERNELSPECS)).to.be(false);
-          expect(args.default).to.be(KERNELSPECS.default);
+          expect(args.default).to.be(specs.default);
           done();
         });
-        let handler = new RequestHandler(() => {
-          handler.respond(200, KERNELSPECS);
-        });
+
+        tester.onRequest = () => {
+          tester.respond(200, specs);
+        };
+        manager.refreshSpecs();
       });
 
     });
@@ -156,10 +139,7 @@ describe('kernel/manager', () => {
     describe('#runningChanged', () => {
 
       it('should be emitted in refreshRunning when the running kernels changed', (done) => {
-        let data: Kernel.IModel[] = [
-          { id: uuid(), name: 'test' },
-          { id: uuid(), name: 'test2' }
-        ];
+        data = [{ id: uuid(), name: 'test' }];
         manager.runningChanged.connect((sender, args) => {
           expect(sender).to.be(manager);
           expect(deepEqual(toArray(args), data)).to.be(true);
@@ -173,23 +153,26 @@ describe('kernel/manager', () => {
 
     });
 
+    describe('#ready()', () => {
+
+      it('should resolve when the manager is ready', (done) => {
+        manager.ready().then(done, done);
+      });
+
+    });
+
     describe('#refreshSpecs()', () => {
 
       it('should update list of kernel specs', (done) => {
-        let ids = {
-          'python': PYTHON_SPEC,
-          'python3': PYTHON3_SPEC
-        };
+        let specs = copy(KERNELSPECS) as Kernel.ISpecModels;
+        specs.default = 'shell';
         tester.onRequest = () => {
-          tester.respond(200, { 'default': 'python',
-                               'kernelspecs': ids });
+          tester.respond(200, specs);
         };
         manager.refreshSpecs().then(() => {
-          let names = Object.keys(manager.specs.kernelspecs);
-          expect(names[0]).to.be('python');
-          expect(names[1]).to.be('python3');
+          expect(manager.specs.default).to.be(specs.default);
           done();
-        });
+        }).catch(done);
       });
 
     });
@@ -197,17 +180,14 @@ describe('kernel/manager', () => {
     describe('#refreshRunning()', () => {
 
       it('should update the running kernels', (done) => {
-        let data = [
-          { id: uuid(), name: 'test' },
-          { id: uuid(), name: 'test2' }
-        ];
+        data = [{ id: uuid(), name: 'test' }];
         tester.onRequest = () => {
           tester.respond(200, data);
         };
         manager.refreshRunning().then(() => {
           let running = toArray(manager.running());
           expect(running[0]).to.eql(data[0]);
-          expect(running[1]).to.eql(data[1]);
+          expect(running[1]).to.be(void 0);
           done();
         });
       });

--- a/test/src/mockxhr.ts
+++ b/test/src/mockxhr.ts
@@ -198,8 +198,8 @@ class MockXMLHttpRequest {
     MockXMLHttpRequest.requests.push(this);
     setTimeout(() => {
       if (MockXMLHttpRequest.requests.indexOf(this) === -1) {
-        console.error('Unhandled request:', JSON.stringify(this));
-        throw new Error(`Unhandled request: ${JSON.stringify(this)}`)
+        console.warn('Unhandled request:', JSON.stringify(this));
+        return;
       }
       var onRequest = MockXMLHttpRequest.onRequest;
       if (onRequest) onRequest(this);

--- a/test/src/session/manager.spec.ts
+++ b/test/src/session/manager.spec.ts
@@ -24,7 +24,7 @@ import {
 } from '../../../lib/utils';
 
 import {
-  RequestHandler, KernelTester, KERNELSPECS
+  KernelTester, KERNELSPECS
 } from '../utils';
 
 
@@ -147,9 +147,9 @@ describe('session/manager', () => {
           done();
         });
 
-        let handler = new RequestHandler(() => {
-          handler.respond(200, specs);
-        });
+        tester.onRequest = () => {
+          tester.respond(200, specs);
+        };
         manager.refreshSpecs();
       });
 
@@ -164,9 +164,9 @@ describe('session/manager', () => {
           expect(deepEqual(toArray(args), sessionModels)).to.be(true);
           done();
         });
-        let handler = new RequestHandler(() => {
-          handler.respond(200, sessionModels);
-        });
+        tester.onRequest = () => {
+          tester.respond(200, sessionModels);
+        };
         manager.refreshRunning();
       });
 
@@ -175,10 +175,9 @@ describe('session/manager', () => {
     describe('#refreshRunning()', () => {
 
       it('should refresh the list of session ids', (done) => {
-        let handler = new RequestHandler();
         let sessionModels = [createSessionModel(), createSessionModel()];
-        handler.onRequest = () => {
-          handler.respond(200, sessionModels);
+        tester.onRequest = () => {
+          tester.respond(200, sessionModels);
         };
         manager.refreshRunning().then(() => {
           let running = toArray(manager.running());
@@ -196,9 +195,9 @@ describe('session/manager', () => {
       it('should refresh the specs', (done) => {
         let specs = copy(KERNELSPECS) as Kernel.ISpecModels;
         specs.default = 'shell';
-        let handler = new RequestHandler(() => {
-          handler.respond(200, specs);
-        });
+        tester.onRequest = () => {
+          tester.respond(200, specs);
+        };
         manager.refreshSpecs().then(() => {
           expect(manager.specs.default).to.be(specs.default);
           done();
@@ -308,9 +307,9 @@ describe('session/manager', () => {
     describe('shutdown()', () => {
 
       it('should shut down a session by id', (done) => {
-        let handler = new RequestHandler(() => {
-          handler.respond(204, { });
-        });
+        tester.onRequest = () => {
+          tester.respond(204, { });
+        };
         manager.shutdown('foo').then(done, done);
       });
 

--- a/test/src/session/manager.spec.ts
+++ b/test/src/session/manager.spec.ts
@@ -119,7 +119,6 @@ describe('session', () => {
           expect(manager.specs.default).to.be(KERNELSPECS.default);
           done();
         });
-        manager.fetchSpecs();
       });
 
     });
@@ -152,7 +151,6 @@ describe('session', () => {
         let handler = new RequestHandler(() => {
           handler.respond(200, KERNELSPECS);
         });
-        manager.fetchSpecs();
       });
 
     });
@@ -182,8 +180,8 @@ describe('session', () => {
         handler.onRequest = () => {
           handler.respond(200, sessionModels);
         };
-        manager.refreshRunning().then(response => {
-          let running = toArray(response);
+        manager.refreshRunning().then(() => {
+          let running = toArray(manager.running());
           expect(running[0]).to.eql(sessionModels[0]);
           expect(running[1]).to.eql(sessionModels[1]);
           done();

--- a/test/src/session/session.spec.ts
+++ b/test/src/session/session.spec.ts
@@ -190,33 +190,6 @@ describe('session', () => {
       });
     });
 
-    it('should be able connect to an existing kernel', (done) => {
-      let sessionModel = createSessionModel();
-      Kernel.startNew().then(kernel => {
-        sessionModel = {
-          id: uuid(),
-          kernel: kernel.model,
-          notebook: {
-            path: uuid()
-          }
-        };
-        tester.onRequest = request => {
-          if (request.method === 'POST') {
-            tester.respond(201, sessionModel);
-          } else {
-            tester.respond(200, { name: sessionModel.kernel.name,
-                                    id: sessionModel.kernel.id });
-          }
-        };
-        let options = createSessionOptions(sessionModel);
-        Session.startNew(options).then(s => {
-          session = s;
-          expect(session.id).to.be(sessionModel.id);
-          done();
-        });
-      });
-    });
-
     it('should accept ajax options', (done) => {
       let sessionModel = createSessionModel();
       tester.onRequest = request => {

--- a/test/src/terminal/manager.spec.ts
+++ b/test/src/terminal/manager.spec.ts
@@ -159,13 +159,14 @@ describe('terminals', () => {
 
     describe('#refreshRunning()', () => {
 
-      it('should list the running session models', (done) => {
+      it('should update the running session models', (done) => {
         let data: TerminalSession.IModel[] = [{ name: 'foo'}, { name: 'bar' }];
         tester.onRequest = () => {
           tester.respond(200, data);
         };
-        manager.refreshRunning().then(models => {
-          expect(deepEqual(data, toArray(models))).to.be(true);
+        manager.refreshRunning().then(() => {
+          let running = toArray(manager.running());
+          expect(deepEqual(data, running)).to.be(true);
           done();
         }).catch(done);
       });

--- a/test/src/terminal/terminal.spec.ts
+++ b/test/src/terminal/terminal.spec.ts
@@ -194,6 +194,14 @@ describe('terminals', () => {
 
     });
 
+    describe('#ready()', () => {
+
+      it('should resolve when the terminal is ready', (done) => {
+        session.ready().then(done, done);
+      });
+
+    });
+
     describe('#send()', () => {
 
       it('should send a message to the socket', (done) => {
@@ -201,7 +209,9 @@ describe('terminals', () => {
           expect(msg.type).to.be('stdin');
           done();
         });
-        session.send({ type: 'stdin', content: [1, 2] });
+        session.ready().then(() => {
+          session.send({ type: 'stdin', content: [1, 2] });
+        });
       });
 
     });


### PR DESCRIPTION
- Adds `ready(): Promise<void>;` functions to all objects that require data from the server before being fully initialized.
- Cleans up auto-refresh behavior of the managers.  They all refresh their listings at 10 second intervals, and kernelspecs are fetched at 61 second intervals (to avoid overlap).
- This auto-refresh behavior should eventually be replaced by a WebSocket connection to the server.
- Verified against JLab using `npm link`.