### PR TITLE
Add more intelligence to the managers

### DIFF
--- a/test/src/kernel/manager.spec.ts
+++ b/test/src/kernel/manager.spec.ts
@@ -144,6 +144,15 @@ describe('kernel/manager', () => {
         manager.refreshRunning();
       });
 
+      it('should be emitted when a kernel is shut down', (done) => {
+        manager.startNew().then(kernel => {
+          manager.runningChanged.connect(() => {
+            done();
+          });
+          return kernel.shutdown();
+        }).catch(done);
+      });
+
     });
 
     describe('#isReady', () => {

--- a/test/src/kernel/manager.spec.ts
+++ b/test/src/kernel/manager.spec.ts
@@ -147,6 +147,7 @@ describe('kernel/manager', () => {
       it('should be emitted when a kernel is shut down', (done) => {
         manager.startNew().then(kernel => {
           manager.runningChanged.connect(() => {
+            manager.dispose();
             done();
           });
           return kernel.shutdown();

--- a/test/src/kernel/manager.spec.ts
+++ b/test/src/kernel/manager.spec.ts
@@ -211,6 +211,13 @@ describe('kernel/manager', () => {
 
       });
 
+      it('should emit a runningChanged signal', (done) => {
+        manager.runningChanged.connect(() => {
+          done();
+        });
+        manager.startNew();
+      });
+
     });
 
     describe('#findById()', () => {
@@ -238,12 +245,28 @@ describe('kernel/manager', () => {
         }).then(done, done);
       });
 
+      it('should emit a runningChanged signal', (done) => {
+        manager.runningChanged.connect(() => {
+          done();
+        });
+        let id = uuid();
+        tester.runningKernels = [{ name: 'foo', id }];
+        manager.connectTo(id);
+      });
+
     });
 
     describe('shutdown()', () => {
 
       it('should shut down a kernel by id', (done) => {
         manager.shutdown('foo').then(done, done);
+      });
+
+      it('should emit a runningChanged signal', (done) => {
+        manager.runningChanged.connect((sender, args) => {
+          done();
+        });
+        manager.shutdown(data[0].id);
       });
 
     });

--- a/test/src/session/manager.spec.ts
+++ b/test/src/session/manager.spec.ts
@@ -180,6 +180,7 @@ describe('session/manager', () => {
       it('should be emitted when a session is shut down', (done) => {
         manager.startNew({ path: 'foo' }).then(s => {
           manager.runningChanged.connect(() => {
+            manager.dispose();
             done();
           });
           return s.shutdown();
@@ -197,6 +198,7 @@ describe('session/manager', () => {
             tester.respond(200, model);
           };
           manager.runningChanged.connect(() => {
+            manager.dispose();
             done();
           });
           return s.rename(model.notebook.path);
@@ -222,6 +224,7 @@ describe('session/manager', () => {
             }
           };
           manager.runningChanged.connect(() => {
+            manager.dispose();
             done();
           });
           return s.changeKernel({ name });

--- a/test/src/session/manager.spec.ts
+++ b/test/src/session/manager.spec.ts
@@ -219,6 +219,13 @@ describe('session/manager', () => {
         }).catch(done);
       });
 
+      it('should emit a runningChanged signal', (done) => {
+        manager.runningChanged.connect(() => {
+          done();
+        });
+        manager.startNew({ path: 'foo.ipynb' });
+      });
+
     });
 
     describe('#findByPath()', () => {
@@ -268,12 +275,28 @@ describe('session/manager', () => {
         }).catch(done);
       });
 
+      it('should emit a runningChanged signal', (done) => {
+        manager.runningChanged.connect(() => {
+          done();
+        });
+        let model = createSessionModel();
+        tester.runningSessions = [model];
+        manager.connectTo(model.id);
+      });
+
     });
 
     describe('shutdown()', () => {
 
       it('should shut down a session by id', (done) => {
         manager.shutdown('foo').then(done, done);
+      });
+
+      it('should emit a runningChanged signal', (done) => {
+        manager.runningChanged.connect((sender, args) => {
+          done();
+        });
+        manager.shutdown(data[0].id);
       });
 
     });

--- a/test/src/terminal/manager.spec.ts
+++ b/test/src/terminal/manager.spec.ts
@@ -192,6 +192,15 @@ describe('terminals', () => {
         manager.refreshRunning();
       });
 
+      it('should be emitted when a session is shut down', (done) => {
+        manager.startNew().then(session => {
+          manager.runningChanged.connect(() => {
+            done();
+          });
+          return session.shutdown();
+        }).catch(done);
+      });
+
     });
 
     describe('#refreshRunning()', () => {

--- a/test/src/terminal/manager.spec.ts
+++ b/test/src/terminal/manager.spec.ts
@@ -133,6 +133,31 @@ describe('terminals', () => {
         }).catch(done);
       });
 
+      it('should emit a runningChanged signal', (done) => {
+        manager.runningChanged.connect(() => {
+          done();
+        });
+        manager.startNew();
+      });
+
+    });
+
+    describe('#connectTo()', () => {
+
+      it('should connect to an existing kernel', (done) => {
+        return manager.connectTo(data[0].name).then(session => {
+          expect(session.name).to.be(data[0].name);
+        }).then(done, done);
+      });
+
+      it('should emit a runningChanged signal', (done) => {
+        tester.runningTerminals = [{ name: 'baz' }];
+        manager.runningChanged.connect(() => {
+          done();
+        });
+        manager.connectTo('baz');
+      });
+
     });
 
     describe('#shutdown()', () => {
@@ -143,6 +168,13 @@ describe('terminals', () => {
         }).then(() => {
           done();
         }).catch(done);
+      });
+
+      it('should emit a runningChanged signal', (done) => {
+        manager.runningChanged.connect((sender, args) => {
+          done();
+        });
+        manager.shutdown(data[0].name);
       });
 
     });

--- a/test/src/terminal/manager.spec.ts
+++ b/test/src/terminal/manager.spec.ts
@@ -195,6 +195,7 @@ describe('terminals', () => {
       it('should be emitted when a session is shut down', (done) => {
         manager.startNew().then(session => {
           manager.runningChanged.connect(() => {
+            manager.dispose();
             done();
           });
           return session.shutdown();

--- a/test/src/terminal/terminal.spec.ts
+++ b/test/src/terminal/terminal.spec.ts
@@ -185,7 +185,7 @@ describe('terminals', () => {
 
     context('#isReady', () => {
 
-      it('should test whether the termainl is ready', (done) => {
+      it('should test whether the terminal is ready', (done) => {
         session.shutdown();
         TerminalSession.startNew().then(s => {
           session = s;


### PR DESCRIPTION
Updates the running session/kernel state when client state changes, avoiding an out of band server request.  It can potentially yield false positives for a kernel or session terminating, but will get back in sync after the next refresh cycle.
