### PR TITLE
add token option

### DIFF
--- a/examples/browser-require/main.py
+++ b/examples/browser-require/main.py
@@ -24,12 +24,13 @@ class MainPageHandler(tornado.web.RequestHandler):
 
 def main():
     # Start a notebook server with cross-origin access.
-    url = "http://localhost:%s" % PORT
-
-    nb_command = [sys.executable, '-m', 'notebook','--no-browser', '--debug',
-                  '--NotebookApp.password=""',
-                  '--notebook-dir=.',
-                  '--NotebookApp.allow_origin="%s"' % url]
+    nb_command = [sys.executable, '-m', 'notebook', '--no-browser',
+                  '--debug',
+                  # FIXME: allow-origin=* only required for notebook < 4.3
+                  '--NotebookApp.allow_origin="*"',
+                  # disable user password:
+                  '--NotebookApp.password=',
+              ]
     nb_server = subprocess.Popen(nb_command, stderr=subprocess.STDOUT,
                                  stdout=subprocess.PIPE)
 

--- a/examples/browser/main.py
+++ b/examples/browser/main.py
@@ -24,10 +24,13 @@ class MainPageHandler(tornado.web.RequestHandler):
 
 def main():
     # Start a notebook server with cross-origin access.
-    url = "http://localhost:%s" % PORT
-
-    nb_command = [sys.executable, '-m', 'notebook', '--no-browser', '--debug',
-                  '--NotebookApp.allow_origin="%s"' % url]
+    nb_command = [sys.executable, '-m', 'notebook', '--no-browser',
+                  '--debug',
+                  # FIXME: allow-origin=* only required for notebook < 4.3
+                  '--NotebookApp.allow_origin="*"',
+                  # disable user password:
+                  '--NotebookApp.password=',
+              ]
     nb_server = subprocess.Popen(nb_command, stderr=subprocess.STDOUT,
                                  stdout=subprocess.PIPE)
 
@@ -39,7 +42,7 @@ def main():
             continue
         print(line)
         if 'Jupyter Notebook is running at:' in line:
-            base_url = re.search('(http.*?)$', line).groups()[0]
+            base_url = re.search(r'(http[^\?]+)', line).groups()[0]
             break
 
     # Wait for the server to finish starting up.

--- a/examples/node/index.js
+++ b/examples/node/index.js
@@ -29,8 +29,10 @@ var options = {
   baseUrl: BASE_URL,
   wsUrl: WS_URL,
   kernelName: 'python',
-  path: 'foo.ipynb'
+  path: 'foo.ipynb',
+  token: 'secret',
 }
+
 services.Session.startNew(options).then(function(session) {
   // Rename the session.
   session.rename('bar.ipynb').then(function() {

--- a/examples/node/main.py
+++ b/examples/node/main.py
@@ -15,7 +15,7 @@ def main():
     url = "http://localhost:%s" % PORT
 
     nb_command = [sys.executable, '-m', 'notebook', '--no-browser', '--debug',
-                  '--NotebookApp.allow_origin="%s"' % url]
+                  '--NotebookApp.token=secret']
     nb_server = subprocess.Popen(nb_command, stderr=subprocess.STDOUT,
                                  stdout=subprocess.PIPE)
 
@@ -27,7 +27,7 @@ def main():
             continue
         print(line)
         if 'Jupyter Notebook is running at:' in line:
-            base_url = re.search('(http.*?)$', line).groups()[0]
+            base_url = re.search('(http.*?)[\?$]', line).groups()[0]
             break
 
     # Wait for the server to finish starting up.

--- a/examples/node/main.py
+++ b/examples/node/main.py
@@ -12,8 +12,6 @@ PORT = 8765
 
 def main():
     # Start a notebook server with cross-origin access.
-    url = "http://localhost:%s" % PORT
-
     nb_command = [sys.executable, '-m', 'notebook', '--no-browser', '--debug',
                   '--NotebookApp.token=secret']
     nb_server = subprocess.Popen(nb_command, stderr=subprocess.STDOUT,
@@ -27,7 +25,12 @@ def main():
             continue
         print(line)
         if 'Jupyter Notebook is running at:' in line:
-            base_url = re.search('(http.*?)[\?$]', line).groups()[0]
+            base_url = re.search(r'(http[^\?]+)', line).groups()[0]
+            token_match = re.search(r'token\=([^&]+)', line)
+            if token_match:
+                token = token_match.groups()[0]
+            else:
+                token = ''
             break
 
     # Wait for the server to finish starting up.
@@ -54,6 +57,9 @@ def main():
 
     # Run the node script with command arguments.
     node_command = ['node', 'index.js', '-baseUrl', base_url]
+    if token:
+        node_command.append('--token=%s' % token)
+
     print('*' * 60)
     print(' '.join(node_command))
     node_proc = subprocess.Popen(node_command, stderr=subprocess.STDOUT,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -80,6 +80,11 @@ namespace ConfigSection {
     baseUrl?: string;
 
     /**
+     * The authentication token for the API.
+     */
+    token?: string;
+
+    /**
      * The default ajax settings.
      */
     ajaxSettings?: IAjaxSettings;
@@ -96,7 +101,7 @@ class DefaultConfigSection implements IConfigSection {
    */
   constructor(options: ConfigSection.IOptions) {
     let baseUrl = options.baseUrl || utils.getBaseUrl();
-    this.ajaxSettings = options.ajaxSettings || {};
+    this.ajaxSettings = utils.ajaxSettingsWithToken(options.ajaxSettings, options.token);
     this._url = utils.urlPathJoin(baseUrl, SERVICE_CONFIG_URL,
                                   encodeURIComponent(options.name));
   }

--- a/src/contents/index.ts
+++ b/src/contents/index.ts
@@ -355,8 +355,7 @@ class ContentsManager implements Contents.IManager {
    */
   constructor(options: ContentsManager.IOptions = {}) {
     this._baseUrl = options.baseUrl || utils.getBaseUrl();
-    options.ajaxSettings = options.ajaxSettings || {};
-    this._ajaxSettings = utils.copy(options.ajaxSettings);
+    this._ajaxSettings = utils.ajaxSettingsWithToken(options.ajaxSettings, options.token);
   }
 
   /**
@@ -817,6 +816,11 @@ namespace ContentsManager {
      * The root url of the server.
      */
     baseUrl?: string;
+
+    /**
+     * The authentication token for the API.
+     */
+    token?: string;
 
     /**
      * The default ajax settings to use for the kernel.

--- a/src/kernel/default.ts
+++ b/src/kernel/default.ts
@@ -82,7 +82,7 @@ class DefaultKernel implements Kernel.IKernel {
     this._ajaxSettings = JSON.stringify(
       utils.ajaxSettingsWithToken(options.ajaxSettings, options.token)
     );
-    this._token = options.token;
+    this._token = options.token || utils.getConfigOption('token');
     this._clientId = options.clientId || utils.uuid();
     this._username = options.username || '';
     this._futures = new Map<string, KernelFutureHandler>();

--- a/src/kernel/default.ts
+++ b/src/kernel/default.ts
@@ -79,7 +79,10 @@ class DefaultKernel implements Kernel.IKernel {
     this._id = id;
     this._baseUrl = options.baseUrl || utils.getBaseUrl();
     this._wsUrl = options.wsUrl || utils.getWsUrl(this._baseUrl);
-    this._ajaxSettings = JSON.stringify(options.ajaxSettings || {});
+    this._ajaxSettings = JSON.stringify(
+      utils.ajaxSettingsWithToken(options.ajaxSettings, options.token)
+    );
+    this._token = options.token;
     this._clientId = options.clientId || utils.uuid();
     this._username = options.username || '';
     this._futures = new Map<string, KernelFutureHandler>();
@@ -226,6 +229,7 @@ class DefaultKernel implements Kernel.IKernel {
       wsUrl: this._wsUrl,
       name: this._name,
       username: this._username,
+      token: this._token,
       ajaxSettings: this.ajaxSettings
     };
     return new DefaultKernel(options, this._id);
@@ -639,15 +643,18 @@ class DefaultKernel implements Kernel.IKernel {
     // Strip any authentication from the display string.
     let parsed = utils.urlParse(partialUrl);
     let display = partialUrl.replace(parsed.auth, '');
-    console.log('Starting WebSocket:', display);
 
     let url = utils.urlPathJoin(
         partialUrl,
         'channels?session_id=' + encodeURIComponent(this._clientId)
     );
+    // if token authentication is in use
+    if (this._token !== '') {
+      url = url + `&token=${encodeURIComponent(this._token)}`;
+    }
+    console.log("new websocket", url);
 
     this._connectionPromise = new utils.PromiseDelegate<void>();
-
     this._ws = new WebSocket(url);
 
     // Ensure incoming binary messages are not Blobs
@@ -908,6 +915,7 @@ class DefaultKernel implements Kernel.IKernel {
   }
 
   private _id = '';
+  private _token = '';
   private _name = '';
   private _baseUrl = '';
   private _wsUrl = '';
@@ -1084,7 +1092,7 @@ namespace Private {
   function getSpecs(options: Kernel.IOptions = {}): Promise<Kernel.ISpecModels> {
     let baseUrl = options.baseUrl || utils.getBaseUrl();
     let url = utils.urlPathJoin(baseUrl, KERNELSPEC_SERVICE_URL);
-    let ajaxSettings: IAjaxSettings = utils.copy(options.ajaxSettings || {});
+    let ajaxSettings: IAjaxSettings = utils.ajaxSettingsWithToken(options.ajaxSettings, options.token);
     ajaxSettings.method = 'GET';
     ajaxSettings.dataType = 'json';
     let promise = utils.ajaxRequest(url, ajaxSettings).then(success => {
@@ -1113,7 +1121,7 @@ namespace Private {
   function listRunning(options: Kernel.IOptions = {}): Promise<Kernel.IModel[]> {
     let baseUrl = options.baseUrl || utils.getBaseUrl();
     let url = utils.urlPathJoin(baseUrl, KERNEL_SERVICE_URL);
-    let ajaxSettings: IAjaxSettings = utils.copy(options.ajaxSettings || {});
+    let ajaxSettings: IAjaxSettings = utils.ajaxSettingsWithToken(options.ajaxSettings, options.token);
     ajaxSettings.method = 'GET';
     ajaxSettings.dataType = 'json';
     ajaxSettings.cache = false;
@@ -1164,7 +1172,7 @@ namespace Private {
     options = options || {};
     let baseUrl = options.baseUrl || utils.getBaseUrl();
     let url = utils.urlPathJoin(baseUrl, KERNEL_SERVICE_URL);
-    let ajaxSettings: IAjaxSettings = utils.copy(options.ajaxSettings || {});
+    let ajaxSettings: IAjaxSettings = utils.ajaxSettingsWithToken(options.ajaxSettings, options.token);
     ajaxSettings.method = 'POST';
     ajaxSettings.data = JSON.stringify({ name: options.name });
     ajaxSettings.dataType = 'json';
@@ -1221,7 +1229,7 @@ namespace Private {
   export
   function shutdown(id: string, options: Kernel.IOptions = {}): Promise<void> {
     let baseUrl = options.baseUrl || utils.getBaseUrl();
-    let ajaxSettings = options.ajaxSettings || {};
+    let ajaxSettings = utils.ajaxSettingsWithToken(options.ajaxSettings, options.token);
     return shutdownKernel(id, baseUrl, ajaxSettings);
   }
 
@@ -1314,7 +1322,7 @@ namespace Private {
     let baseUrl = options.baseUrl || utils.getBaseUrl();
     let url = utils.urlPathJoin(baseUrl, KERNEL_SERVICE_URL,
                                 encodeURIComponent(id));
-    let ajaxSettings = options.ajaxSettings || {};
+    let ajaxSettings = utils.ajaxSettingsWithToken(options.ajaxSettings, options.token);
     ajaxSettings.method = 'GET';
     ajaxSettings.dataType = 'json';
     ajaxSettings.cache = false;

--- a/src/kernel/kernel.ts
+++ b/src/kernel/kernel.ts
@@ -515,6 +515,11 @@ namespace Kernel {
     clientId?: string;
 
     /**
+     * The authentication token for the API.
+     */
+    token?: string;
+
+    /**
      * The default ajax settings to use for the kernel.
      */
     ajaxSettings?: IAjaxSettings;

--- a/src/kernel/manager.ts
+++ b/src/kernel/manager.ts
@@ -42,7 +42,8 @@ class KernelManager implements Kernel.IManager {
   constructor(options: Kernel.IOptions = {}) {
     this._baseUrl = options.baseUrl || utils.getBaseUrl();
     this._wsUrl = options.wsUrl || utils.getWsUrl(this._baseUrl);
-    this._ajaxSettings = JSON.stringify(options.ajaxSettings || {});
+    this._token = options.token || '';
+    this._ajaxSettings = JSON.stringify(utils.ajaxSettingsWithToken(options.ajaxSettings, options.token));
 
     // Initialize internal data.
     this._readyPromise = this._refreshSpecs().then(() => {
@@ -254,6 +255,7 @@ class KernelManager implements Kernel.IManager {
   private _refreshSpecs(): Promise<void> {
     let options = {
       baseUrl: this._baseUrl,
+      token: this._token,
       ajaxSettings: this.ajaxSettings
     };
     return Kernel.getSpecs(options).then(specs => {
@@ -283,12 +285,14 @@ class KernelManager implements Kernel.IManager {
   private _getOptions(options: Kernel.IOptions = {}): Kernel.IOptions {
     options.baseUrl = this._baseUrl;
     options.wsUrl = this._wsUrl;
+    options.token = this._token;
     options.ajaxSettings = options.ajaxSettings || this.ajaxSettings;
     return options;
   }
 
   private _baseUrl = '';
   private _wsUrl = '';
+  private _token = '';
   private _ajaxSettings = '';
   private _running: Kernel.IModel[] = [];
   private _specs: Kernel.ISpecModels = null;

--- a/src/kernel/manager.ts
+++ b/src/kernel/manager.ts
@@ -42,7 +42,7 @@ class KernelManager implements Kernel.IManager {
   constructor(options: Kernel.IOptions = {}) {
     this._baseUrl = options.baseUrl || utils.getBaseUrl();
     this._wsUrl = options.wsUrl || utils.getWsUrl(this._baseUrl);
-    this._token = options.token || '';
+    this._token = options.token || utils.getConfigOption('token');
     this._ajaxSettings = JSON.stringify(utils.ajaxSettingsWithToken(options.ajaxSettings, options.token));
 
     // Initialize internal data.

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -30,7 +30,7 @@ import {
 } from './terminal';
 
 import {
-  IAjaxSettings, getBaseUrl, getWsUrl
+  IAjaxSettings, getBaseUrl, getWsUrl, ajaxSettingsWithToken
 } from './utils';
 
 
@@ -46,7 +46,7 @@ class ServiceManager implements ServiceManager.IManager {
     options = options || {};
     options.wsUrl = options.wsUrl || getWsUrl();
     options.baseUrl = options.baseUrl || getBaseUrl();
-    options.ajaxSettings = options.ajaxSettings || {};
+    options.ajaxSettings = ajaxSettingsWithToken(options.ajaxSettings, options.token);
     this._sessionManager = new SessionManager(options);
     this._contentsManager = new ContentsManager(options);
     this._terminalManager = new TerminalManager(options);
@@ -206,6 +206,11 @@ namespace ServiceManager {
      * The base ws url of the server.
      */
     wsUrl?: string;
+
+    /**
+     * The authentication token for the API.
+     */
+    token?: string;
 
     /**
      * The ajax settings for the manager.

--- a/src/session/default.ts
+++ b/src/session/default.ts
@@ -57,7 +57,11 @@ class DefaultSession implements Session.ISession {
     this._path = options.path;
     this._baseUrl = options.baseUrl || utils.getBaseUrl();
     this._uuid = utils.uuid();
-    this._ajaxSettings = JSON.stringify(options.ajaxSettings || {});
+    this._ajaxSettings = JSON.stringify(
+      utils.ajaxSettingsWithToken(options.ajaxSettings || {}, options.token)
+    );
+    console.log(this._ajaxSettings);
+    this._token = options.token;
     Private.runningSessions.pushBack(this);
     this.setupKernel(kernel);
     this._options = utils.copy(options);
@@ -353,6 +357,7 @@ class DefaultSession implements Session.ISession {
   private _id = '';
   private _path = '';
   private _ajaxSettings = '';
+  private _token = '';
   private _kernel: Kernel.IKernel = null;
   private _uuid = '';
   private _baseUrl = '';
@@ -442,7 +447,7 @@ namespace Private {
   function listRunning(options: Session.IOptions = {}): Promise<Session.IModel[]> {
     let baseUrl = options.baseUrl || utils.getBaseUrl();
     let url = utils.urlPathJoin(baseUrl, SESSION_SERVICE_URL);
-    let ajaxSettings: IAjaxSettings = utils.copy(options.ajaxSettings || {});
+    let ajaxSettings = utils.ajaxSettingsWithToken(options.ajaxSettings, options.token);
     ajaxSettings.method = 'GET';
     ajaxSettings.dataType = 'json';
     ajaxSettings.cache = false;
@@ -541,7 +546,7 @@ namespace Private {
   export
   function shutdown(id: string, options: Session.IOptions = {}): Promise<void> {
     let baseUrl = options.baseUrl || utils.getBaseUrl();
-    let ajaxSettings = options.ajaxSettings || {};
+    let ajaxSettings = utils.ajaxSettingsWithToken(options.ajaxSettings, options.token);
     return shutdownSession(id, baseUrl, ajaxSettings);
   }
 
@@ -557,7 +562,7 @@ namespace Private {
       kernel: { name: options.kernelName, id: options.kernelId },
       notebook: { path: options.path }
     };
-    let ajaxSettings: IAjaxSettings = utils.copy(options.ajaxSettings || {});
+    let ajaxSettings: IAjaxSettings = utils.ajaxSettingsWithToken(options.ajaxSettings, options.token);
     ajaxSettings.method = 'POST';
     ajaxSettings.dataType = 'json';
     ajaxSettings.data = JSON.stringify(model);
@@ -588,6 +593,7 @@ namespace Private {
       wsUrl: options.wsUrl,
       username: options.username,
       clientId: options.clientId,
+      token: options.token,
       ajaxSettings: options.ajaxSettings
     };
     return Kernel.connectTo(options.kernelId, kernelOptions);
@@ -618,7 +624,7 @@ namespace Private {
     options = options || {};
     let baseUrl = options.baseUrl || utils.getBaseUrl();
     let url = getSessionUrl(baseUrl, id);
-    let ajaxSettings = options.ajaxSettings || {};
+    let ajaxSettings = utils.ajaxSettingsWithToken(options.ajaxSettings, options.token);
     ajaxSettings.method = 'GET';
     ajaxSettings.dataType = 'json';
     ajaxSettings.cache = false;

--- a/src/session/default.ts
+++ b/src/session/default.ts
@@ -61,7 +61,7 @@ class DefaultSession implements Session.ISession {
       utils.ajaxSettingsWithToken(options.ajaxSettings || {}, options.token)
     );
     console.log(this._ajaxSettings);
-    this._token = options.token;
+    this._token = options.token || utils.getConfigOption('token');
     Private.runningSessions.pushBack(this);
     this.setupKernel(kernel);
     this._options = utils.copy(options);

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -326,6 +326,11 @@ namespace Session {
     clientId?: string;
 
     /**
+     * The authentication token for the API.
+     */
+    token?: string;
+
+    /**
      * The default ajax settings to use for the session.
      */
     ajaxSettings?: IAjaxSettings;

--- a/src/terminal/default.ts
+++ b/src/terminal/default.ts
@@ -42,10 +42,10 @@ class DefaultTerminalSession implements TerminalSession.ISession {
   constructor(name: string, options: TerminalSession.IOptions = {}) {
     this._name = name;
     this._baseUrl = options.baseUrl || utils.getBaseUrl();
+    this._token = options.token || utils.getConfigOption('token');
     this._ajaxSettings = JSON.stringify(
       utils.ajaxSettingsWithToken(options.ajaxSettings, this._token)
     );
-    this._token = options.token;
     this._wsUrl = options.wsUrl || utils.getWsUrl(this._baseUrl);
     this._readyPromise = this._initializeSocket();
   }

--- a/src/terminal/manager.ts
+++ b/src/terminal/manager.ts
@@ -275,6 +275,11 @@ namespace TerminalManager {
     wsUrl?: string;
 
     /**
+     * The authentication token for the API.
+     */
+    token?: string;
+
+    /**
      * The Ajax settings used for server requests.
      */
     ajaxSettings?: utils.IAjaxSettings;

--- a/src/terminal/terminal.ts
+++ b/src/terminal/terminal.ts
@@ -170,6 +170,11 @@ namespace TerminalSession {
     wsUrl?: string;
 
     /**
+     * The authentication token for the API.
+     */
+    token?: string;
+
+    /**
      * The Ajax settings used for server requests.
      */
     ajaxSettings?: utils.IAjaxSettings;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -547,3 +547,24 @@ function getWsUrl(baseUrl?: string): string {
   }
   return wsUrl;
 }
+
+/**
+ * Add token to ajaxSettings.requestHeaders if defined.
+ * Always returns a copy of ajaxSettings, and a dict.
+ */
+export
+function ajaxSettingsWithToken(ajaxSettings?: IAjaxSettings, token?: string): IAjaxSettings {
+  if (!ajaxSettings) {
+    ajaxSettings = {};
+  } else {
+    ajaxSettings = copy(ajaxSettings);
+  }
+  if (!token || token === '') {
+    return ajaxSettings;
+  }
+  if (!ajaxSettings.requestHeaders) {
+    ajaxSettings.requestHeaders = {}
+  }
+  ajaxSettings.requestHeaders['Authorization'] = `token ${token}`;
+  return ajaxSettings;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -559,7 +559,10 @@ function ajaxSettingsWithToken(ajaxSettings?: IAjaxSettings, token?: string): IA
   } else {
     ajaxSettings = copy(ajaxSettings);
   }
-  if (!token || token === '') {
+  if (!token) {
+    token = getConfigOption('token');
+  }
+  if (!token || token == '') {
     return ajaxSettings;
   }
   if (!ajaxSettings.requestHeaders) {

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -72,7 +72,9 @@ def start_notebook():
 
 def run_mocha(options, base_url, token):
     mocha_command = ['mocha', '--timeout', '20000', 'build/integration.js',
-                     '--baseUrl=%s' % base_url, '--token=%s' % token]
+                     '--baseUrl=%s' % base_url]
+    if token:
+        mocha_command.append('--token=%s' % token)
     return subprocess.check_call(mocha_command, stderr=subprocess.STDOUT)
 
 

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -21,9 +21,15 @@ with open(os.path.join(root_dir, 'src', 'temp.txt'), 'w') as fid:
 KARMA_PORT = 9876
 
 
+
 def start_notebook():
     nb_command = [sys.executable, '-m', 'notebook', root_dir, '--no-browser',
-                  '--debug', '--NotebookApp.allow_origin="*"']
+                  '--debug',
+                  # FIXME: allow-origin=* only required for notebook < 4.3
+                  '--NotebookApp.allow_origin="*"',
+                  # disable user password:
+                  '--NotebookApp.password=',
+              ]
     nb_server = subprocess.Popen(nb_command, stderr=subprocess.STDOUT,
                                  stdout=subprocess.PIPE)
 
@@ -34,7 +40,12 @@ def start_notebook():
             continue
         print(line)
         if 'Jupyter Notebook is running at:' in line:
-            base_url = re.search('(http.*?)$', line).groups()[0]
+            base_url = re.search(r'(http[^\?]+)', line).groups()[0]
+            token_match = re.search(r'token\=([^&]+)', line)
+            if token_match:
+                token = token_match.groups()[0]
+            else:
+                token = ''
             break
 
     while 1:
@@ -56,12 +67,12 @@ def start_notebook():
     thread.setDaemon(True)
     thread.start()
 
-    return nb_server, base_url
+    return nb_server, base_url, token
 
 
-def run_mocha(options, base_url):
+def run_mocha(options, base_url, token):
     mocha_command = ['mocha', '--timeout', '20000', 'build/integration.js',
-                     '--baseUrl=%s' % base_url]
+                     '--baseUrl=%s' % base_url, '--token=%s' % token]
     return subprocess.check_call(mocha_command, stderr=subprocess.STDOUT)
 
 
@@ -75,10 +86,10 @@ if __name__ == '__main__':
                            help="Whether to enter debug mode in Karma")
     options = argparser.parse_args(sys.argv[1:])
 
-    nb_server, base_url = start_notebook()
+    nb_server, base_url, token = start_notebook()
 
     try:
-        resp = run_mocha(options, base_url)
+        resp = run_mocha(options, base_url, token)
     except subprocess.CalledProcessError:
         resp = 1
     finally:


### PR DESCRIPTION
added to ajaxSettings.requestHeaders['Authorization'] for ajax requests, and url parameter for websockets.

This should work with Kernel Gateway now, and notebook >= 4.3. It should be safely ignored on notebook < 4.3.

closes #251