### PR TITLE
Move attachments field to raw and markdown cells

### DIFF
--- a/src/nbformat.ts
+++ b/src/nbformat.ts
@@ -214,11 +214,6 @@ namespace nbformat {
      * Raw cell metadata format for nbconvert.
      */
     format?: string;
-
-    /**
-     * Media attachments (e.g. inline images).
-     */
-    attachments?: IAttachments;
   }
 
   /**
@@ -235,6 +230,11 @@ namespace nbformat {
      * Cell-level metadata.
      */
     metadata: IRawCellMetadata;
+
+    /**
+     * Cell attachments.
+     */
+    attachments?: IAttachments;
   }
 
   /**
@@ -246,6 +246,11 @@ namespace nbformat {
      * String identifying the type of cell.
      */
     cell_type: 'markdown';
+
+    /**
+     * Cell attachments.
+     */
+    attachments?: IAttachments;
   }
 
   /**
@@ -262,11 +267,6 @@ namespace nbformat {
      * Whether the cell's output is scrolled, unscrolled, or autoscrolled.
      */
     scrolled?: boolean | 'auto';
-
-    /**
-     * Media attachments (e.g. inline images).
-     */
-    attachments?: IAttachments;
   }
 
   /**


### PR DESCRIPTION
Previously, the `attachments` field was specified in the metadata of raw and code cells. Corrected to follow the specifications in the docs: http://nbformat.readthedocs.io/en/latest/format_description.html#cell-attachments.