### PR TITLE
include xsrf cookie in ajax requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "rimraf": "^2.4.2",
     "text-encoding": "^0.5.2",
     "typedoc": "^0.5.0",
-    "typescript": "^2.0.7",
+    "typescript": "~2.0.7",
     "webpack": "^1.13.1",
     "ws": "^1.0.1",
     "xmlhttprequest": "^1.8.0"

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -274,6 +274,11 @@ interface IAjaxError {
 }
 
 
+function _getCookie(name: string) {
+  // from tornado docs: http://www.tornadoweb.org/en/stable/guide/security.html
+  var r = document.cookie.match("\\b" + name + "=([^;]*)\\b");
+  return r ? r[1] : void 0;
+}
 /**
  * Asynchronous XMLHTTPRequest handler.
  *
@@ -307,6 +312,14 @@ function ajaxRequest(url: string, ajaxSettings: IAjaxSettings): Promise<IAjaxSuc
     if (!!ajaxSettings.withCredentials) {
       xhr.withCredentials = true;
     }
+
+    if (typeof document !== 'undefined' && document.cookie) {
+      let xsrfToken = _getCookie('_xsrf');
+      if (xsrfToken !== void 0) {
+        xhr.setRequestHeader('X-XSRFToken', xsrfToken);
+      }
+    }
+
     if (ajaxSettings.requestHeaders !== void 0) {
        for (let prop in ajaxSettings.requestHeaders) {
          xhr.setRequestHeader(prop, ajaxSettings.requestHeaders[prop]);


### PR DESCRIPTION
needed for notebook 4.3.1 security fix

cf https://github.com/jupyterlab/jupyterlab/issues/1435