### PR TITLE
Fix handling of config data

### DIFF
--- a/src/terminal/default.ts
+++ b/src/terminal/default.ts
@@ -215,8 +215,8 @@ namespace DefaultTerminalSession {
    */
   export
   function isAvailable(): boolean {
-    let available = utils.getConfigOption('terminalsAvailable');
-    return available === 'True' || available === 'true';
+    let available = String(utils.getConfigOption('terminalsAvailable'));
+    return available.toLowerCase() === 'true';
   }
 
   /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -529,7 +529,7 @@ function getConfigOption(name: string): string {
     }
   }
   configData = deepFreeze(configData);
-  return String(configData[name]);
+  return configData[name];
 }
 
 


### PR DESCRIPTION
This was breaking the `notebook` example in `JupyterLab` because the `wsUrl` was being picked up as `"undefined"`.