### PR TITLE
Use promise for getDownloadUrl

### DIFF
--- a/src/contents/index.ts
+++ b/src/contents/index.ts
@@ -232,9 +232,10 @@ namespace Contents {
     /**
      * Get an encoded download url given a file path.
      *
-     * @param path - An absolute POSIX file path on the server.
+     * @param A promise which resolves with the absolute POSIX
+     *   file path on the server.
      */
-    getDownloadUrl(path: string): string;
+    getDownloadUrl(path: string): Promise<string>;
 
     /**
      * Create a new untitled file or directory in the specified directory path.
@@ -453,9 +454,9 @@ class ContentsManager implements Contents.IManager {
    * use [[ContentsManager.getAbsolutePath]] to get an absolute
    * path if necessary.
    */
-  getDownloadUrl(path: string): string {
-    return utils.urlPathJoin(this._baseUrl, FILES_URL,
-                             utils.urlEncodeParts(path));
+  getDownloadUrl(path: string): Promise<string> {
+    return Promise.resolve(utils.urlPathJoin(this._baseUrl, FILES_URL,
+                                             utils.urlEncodeParts(path)));
   }
 
   /**

--- a/test/src/contents/index.spec.ts
+++ b/test/src/contents/index.spec.ts
@@ -231,24 +231,29 @@ describe('contents', () => {
 
     it('should get the url of a file', () => {
       let contents = new ContentsManager({ baseUrl: 'http://foo', });
-      let url = contents.getDownloadUrl('bar.txt');
-      expect(url).to.be('http://foo/files/bar.txt');
-      url = contents.getDownloadUrl('fizz/buzz/bar.txt');
-      expect(url).to.be('http://foo/files/fizz/buzz/bar.txt');
-      url = contents.getDownloadUrl('/bar.txt');
-      expect(url).to.be('http://foo/files/bar.txt');
+      contents.getDownloadUrl('bar.txt').then((url)=>{
+        expect(url).to.be('http://foo/files/bar.txt');
+      });
+      contents.getDownloadUrl('fizz/buzz/bar.txt').then((url)=>{
+        expect(url).to.be('http://foo/files/fizz/buzz/bar.txt');
+      });
+      contents.getDownloadUrl('/bar.txt').then((url)=>{
+        expect(url).to.be('http://foo/files/bar.txt');
+      });
     });
 
     it('should encode characters', () => {
       let contents = new ContentsManager({ baseUrl: 'http://foo', });
-      let url = contents.getDownloadUrl('b ar?3.txt');
-      expect(url).to.be('http://foo/files/b%20ar%3F3.txt');
+      contents.getDownloadUrl('b ar?3.txt').then((url)=>{
+        expect(url).to.be('http://foo/files/b%20ar%3F3.txt');
+      });
     });
 
     it('should not handle relative paths', () => {
       let contents = new ContentsManager({ baseUrl: 'http://foo', });
-      let url = contents.getDownloadUrl('fizz/../bar.txt');
-      expect(url).to.be('http://foo/files/fizz/../bar.txt');
+      contents.getDownloadUrl('fizz/../bar.txt').then((url)=>{
+        expect(url).to.be('http://foo/files/fizz/../bar.txt');
+      });
     });
 
   });

--- a/test/src/contents/index.spec.ts
+++ b/test/src/contents/index.spec.ts
@@ -229,30 +229,32 @@ describe('contents', () => {
 
   describe('#getDownloadUrl()', () => {
 
-    it('should get the url of a file', () => {
+    it('should get the url of a file', (done) => {
       let contents = new ContentsManager({ baseUrl: 'http://foo', });
-      contents.getDownloadUrl('bar.txt').then((url)=>{
-        expect(url).to.be('http://foo/files/bar.txt');
-      });
-      contents.getDownloadUrl('fizz/buzz/bar.txt').then((url)=>{
-        expect(url).to.be('http://foo/files/fizz/buzz/bar.txt');
-      });
-      contents.getDownloadUrl('/bar.txt').then((url)=>{
-        expect(url).to.be('http://foo/files/bar.txt');
+      let test1 = contents.getDownloadUrl('bar.txt');
+      let test2 = contents.getDownloadUrl('fizz/buzz/bar.txt');
+      let test3 = contents.getDownloadUrl('/bar.txt');
+      Promise.all([test1,test2,test3]).then((urls)=>{
+        expect(urls[0]).to.be('http://foo/files/bar.txt');
+        expect(urls[1]).to.be('http://foo/files/fizz/buzz/bar.txt');
+        expect(urls[2]).to.be('http://foo/files/bar.txt');
+        done();
       });
     });
 
-    it('should encode characters', () => {
+    it('should encode characters', (done) => {
       let contents = new ContentsManager({ baseUrl: 'http://foo', });
       contents.getDownloadUrl('b ar?3.txt').then((url)=>{
         expect(url).to.be('http://foo/files/b%20ar%3F3.txt');
+        done();
       });
     });
 
-    it('should not handle relative paths', () => {
+    it('should not handle relative paths', (done) => {
       let contents = new ContentsManager({ baseUrl: 'http://foo', });
       contents.getDownloadUrl('fizz/../bar.txt').then((url)=>{
         expect(url).to.be('http://foo/files/fizz/../bar.txt');
+        done();
       });
     });
 


### PR DESCRIPTION
In some cases the downloadUrl for a file may not be computable client-side and requires some server communication. Cf. jupyterlab/jupyterlab#1495 and [https://github.com/ian-r-rose/jupyterlab_google_drive/tree/filebrowser]()